### PR TITLE
Fix quest validation and various type errors

### DIFF
--- a/src/data/schemas.ts
+++ b/src/data/schemas.ts
@@ -121,7 +121,8 @@ export const QueteSchema = z.object({
     itemCount: z.number().int().optional(),
     timeLimit: z.number().int().optional(), // en secondes
     skillId: z.string().optional(),
-    monsterType: z.string().optional()
+    monsterType: z.string().optional(),
+    classId: z.string().optional()
   }),
   rewards: z.object({
     gold: z.number().int(),

--- a/src/features/dungeons/DungeonsView.tsx
+++ b/src/features/dungeons/DungeonsView.tsx
@@ -69,15 +69,21 @@ export function DungeonsView() {
     if (proposedQuests && proposedQuests.length > 0) {
       const questIds = proposedQuests.map(q => q.id);
       acceptMultipleQuests(questIds);
-      enterDungeon(proposedQuests[0].requirements.dungeonId);
+      const dungeonId = proposedQuests[0].requirements.dungeonId;
+      if (dungeonId) {
+          enterDungeon(dungeonId);
+      }
       setProposedQuests(null);
     }
   };
 
   const handleDeclineQuestAndEnter = () => {
     if (proposedQuests && proposedQuests.length > 0) {
-      enterDungeon(proposedQuests[0].requirements.dungeonId);
-      setProposedQuests(null);
+        const dungeonId = proposedQuests[0].requirements.dungeonId;
+        if (dungeonId) {
+            enterDungeon(dungeonId);
+        }
+        setProposedQuests(null);
     }
   };
 

--- a/src/state/gameStore.ts
+++ b/src/state/gameStore.ts
@@ -1054,7 +1054,7 @@ export const useGameStore = create<GameState>()(
               if (quete.type === 'chasse' && req.dungeonId === currentDungeon?.id && !enemy.isBoss) {
                   activeQuest.progress++;
                   progressMade = true;
-              } else if (quete.type === 'chasse_boss' && enemy.isBoss && enemy.templateId === req.bossId) { // <-- Ligne modifiée
+              } else if (quete.type === 'chasse_boss' && req.dungeonId === currentDungeon?.id && enemy.isBoss && enemy.templateId === req.bossId) {
                   activeQuest.progress++;
                   progressMade = true;
               } else if (quete.type === 'collecte' && req.dungeonId === currentDungeon?.id) {
@@ -1127,7 +1127,7 @@ export const useGameStore = create<GameState>()(
                               const { quete } = activeQuest;
                               if (quete.type === 'nettoyage' && quete.requirements.dungeonId === currentDungeon.id) {
                                 activeQuest.progress = state.player.completedDungeons[currentDungeon.id];
-                              } else if (quete.type === 'defi' && quete.requirements.timeLimit && dungeonDuration <= quete.requirements.timeLimit) {
+                              } else if (quete.type === 'defi' && quete.requirements.dungeonId === currentDungeon.id && quete.requirements.timeLimit && dungeonDuration <= quete.requirements.timeLimit) {
                                 activeQuest.progress = 1;
                               }
 


### PR DESCRIPTION
This commit addresses a bug where speedrun challenges (`defi` quests) could be incorrectly completed by finishing any dungeon within the time limit, not just the specified one.

- Added a `dungeonId` check to the validation logic for `defi` quests of type `timeLimit` in `gameStore.ts`.
- Added a similar `dungeonId` check for `chasse_boss` quests to prevent similar bugs.

Additionally, this commit fixes several TypeScript errors that were preventing the build from passing:
- Updated the `QueteSchema` in `src/data/schemas.ts` to include the optional `classId` property in the requirements, matching the data structure found in `quests.json`.
- Added null checks in `src/features/dungeons/DungeonsView.tsx` before calling `enterDungeon` to handle cases where `dungeonId` could be undefined, resolving type errors.