### PR TITLE
fix: Prevent crash in item scoring and correct item data

### DIFF
--- a/public/data/items.json
+++ b/public/data/items.json
@@ -715,7 +715,19 @@
         "type": "quest",
         "rarity": "Commun",
         "desc": "Un croc pointu prélevé sur une chauve-souris. Utile pour certaines quêtes.",
-        "vendorPrice": 1
+        "vendorPrice": 1,
+        "niveauMin": 1,
+        "affixes": []
+      },
+      {
+        "id": "bat_fang_heroic",
+        "name": "Croc de chauve-souris Héroïque",
+        "type": "quest",
+        "rarity": "Commun",
+        "desc": "[Héroïque] Un croc pointu prélevé sur une chauve-souris héroïque.",
+        "vendorPrice": 5,
+        "niveauMin": 51,
+        "affixes": []
       }
   ]
 }

--- a/src/state/gameStore.ts
+++ b/src/state/gameStore.ts
@@ -244,9 +244,11 @@ const STAT_WEIGHTS: Record<PlayerClassId, Partial<Record<keyof Stats, number>>> 
 
 export const calculateItemScore = (item: Item, classId: PlayerClassId): number => {
     let score = 0;
+    if (!item || !classId) return 0;
+
     const weights = STAT_WEIGHTS[classId];
 
-    item.affixes.forEach(affix => {
+    (item.affixes || []).forEach(affix => {
         const statKey = affix.ref as keyof Stats;
         const weight = weights[statKey] || 0.1;
         score += affix.val * weight;


### PR DESCRIPTION
This commit addresses a TypeError that occurred in the `calculateItemScore` function.

The bug was caused by a quest item (`bat_fang`) that was missing the `affixes` and `niveauMin` properties. When the `calculateItemScore` function attempted to access `item.affixes.forEach`, it crashed because `item.affixes` was undefined.

The following changes have been made to resolve this issue:

1.  **Robust Function:** The `calculateItemScore` function in `src/state/gameStore.ts` has been made more robust. It now checks if `item.affixes` is defined before calling `forEach` on it, preventing similar crashes in the future if other items have missing data.

2.  **Data Correction:** The `bat_fang` item in `public/data/items.json` has been corrected to include the missing `affixes` and `niveauMin` properties.

3.  **Heroic Quest Item:** Added the `bat_fang_heroic` item to support the new heroic questlines.