### PR TITLE
Fix(loot): Correct loot generation and vendor inventory

### DIFF
--- a/src/features/vendors/VendorsView.tsx
+++ b/src/features/vendors/VendorsView.tsx
@@ -37,6 +37,7 @@ function BuyTab() {
 
     const vendorItems = React.useMemo(() =>
         gameItems.filter(item =>
+            item.slot &&
             item.vendorPrice && item.vendorPrice > 0 && item.niveauMin <= playerLevel + 5
         ).sort((a,b) => a.niveauMin - b.niveauMin),
     [gameItems, playerLevel]);


### PR DESCRIPTION
This commit addresses two issues that were preventing players from obtaining equipment:

1.  **Dungeon Loot:** The `resolveLoot` function was incorrectly using quest items as templates for procedural item generation. It was also halting loot generation after a quest item was dropped.
    - Quest item drops are now handled separately in `handleEnemyDeath` to allow both quest items and equipment to drop from the same monster.
    - The procedural item generator in `resolveLoot` now only uses equippable items (items with a `slot`) as templates.

2.  **Vendor Inventory:** The merchant was selling quest items because the inventory filter was only checking for `vendorPrice`.
    - The filter in `VendorsView.tsx` has been updated to also ensure items have a `slot`, so only equippable items are sold.