### PR TITLE
feat(gambler): Improve gambler feature with item display and comparison

### DIFF
--- a/src/components/ItemTooltip.tsx
+++ b/src/components/ItemTooltip.tsx
@@ -66,7 +66,7 @@ function ItemStat({ label, value, comparison }: { label: string, value: string |
     );
 }
 
-function ItemTooltipContent({ item, equippedItem }: { item: Item, equippedItem?: Item | null }) {
+export function ItemTooltipContent({ item, equippedItem }: { item: Item, equippedItem?: Item | null }) {
     if (!item) return null;
 
     const comparisonStats: Partial<Record<StatKey, ComparisonResult>> = {};

--- a/src/features/vendors/GamblerView.tsx
+++ b/src/features/vendors/GamblerView.tsx
@@ -1,17 +1,35 @@
-// src/features/vendors/GamblerView.tsx
 import React from 'react';
 import { useGameStore } from '@/state/gameStore';
 import { Button } from '@/components/ui/button';
+import { Item } from '@/lib/types';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { ItemTooltipContent } from '@/components/ItemTooltip';
 
 const itemSlots = ["weapon", "head", "chest", "legs", "hands", "feet", "belt", "amulet", "ring", "trinket", "offhand"];
 
 export const GamblerView: React.FC = () => {
-    const { gambleForItem, worldTier } = useGameStore(state => ({
+    const { gambleForItem, worldTier, equipment, gold } = useGameStore(state => ({
         gambleForItem: state.gambleForItem,
         worldTier: state.worldTier,
+        equipment: state.inventory.equipment,
+        gold: state.inventory.gold,
     }));
+    const [lastGambledItem, setLastGambledItem] = React.useState<Item | null>(null);
 
     const cost = 100 * worldTier;
+
+    const handleGamble = (slot: string) => {
+        if (gold < cost) {
+            console.log("Not enough gold");
+            return;
+        }
+        const item = gambleForItem(slot);
+        if (item) {
+            setLastGambledItem(item);
+        }
+    };
+
+    const equippedItem = lastGambledItem ? equipment[lastGambledItem.slot as keyof typeof equipment] : null;
 
     return (
         <div className="p-4">
@@ -19,11 +37,35 @@ export const GamblerView: React.FC = () => {
             <p className="text-sm text-muted-foreground mb-4">Tentez votre chance ! Le coût est de {cost} or.</p>
             <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-2">
                 {itemSlots.map(slot => (
-                    <Button key={slot} onClick={() => gambleForItem(slot)} variant="outline">
+                    <Button key={slot} onClick={() => handleGamble(slot)} variant="outline" disabled={gold < cost}>
                         {slot.charAt(0).toUpperCase() + slot.slice(1)}
                     </Button>
                 ))}
             </div>
+
+            <Dialog open={!!lastGambledItem} onOpenChange={(isOpen) => !isOpen && setLastGambledItem(null)}>
+                <DialogContent>
+                    <DialogHeader>
+                        <DialogTitle>Vous avez obtenu un objet !</DialogTitle>
+                    </DialogHeader>
+                    {lastGambledItem && (
+                        <div className="flex space-x-4">
+                            <div className="w-1/2">
+                                <h3 className="font-semibold mb-2 text-center">Nouvel Objet</h3>
+                                <ItemTooltipContent item={lastGambledItem} equippedItem={equippedItem} />
+                            </div>
+                            <div className="w-1/2">
+                                <h3 className="font-semibold mb-2 text-center">Objet Équipé</h3>
+                                {equippedItem ? (
+                                    <ItemTooltipContent item={equippedItem} />
+                                ) : (
+                                    <p className="text-sm text-muted-foreground text-center mt-4">Aucun objet équipé dans cet emplacement.</p>
+                                )}
+                            </div>
+                        </div>
+                    )}
+                </DialogContent>
+            </Dialog>
         </div>
     );
 };


### PR DESCRIPTION
The gambler feature was previously lacking feedback, leaving the user unaware of the item they received.

This commit introduces a dialog that appears after gambling, displaying the newly acquired item and comparing it with the currently equipped item. This provides immediate feedback and allows the user to see if the item is an upgrade.

- Modified `gambleForItem` in `gameStore.ts` to return the new item.
- Updated `GamblerView.tsx` to display the new item in a dialog with comparison.
- Exported `ItemTooltipContent` to be reused in the gambler view.