### PR TITLE
fix: Correct loot and vendor issues and improve rewards

### DIFF
--- a/public/data/items.json
+++ b/public/data/items.json
@@ -1,6 +1,140 @@
 {
     "items": [
       {
+        "id": "worn_leather_cap",
+        "name": "Coiffe en cuir usé",
+        "slot": "head",
+        "niveauMin": 1,
+        "rarity": "Commun",
+        "affixes": [
+          { "ref": "Armure", "val": 5 }
+        ],
+        "tagsClasse": ["common"],
+        "vendorPrice": 5
+      },
+      {
+        "id": "patched_leather_tunic",
+        "name": "Tunique en cuir rapiécé",
+        "slot": "chest",
+        "niveauMin": 1,
+        "rarity": "Commun",
+        "affixes": [
+          { "ref": "Armure", "val": 10 },
+          { "ref": "PV", "val": 5 }
+        ],
+        "tagsClasse": ["common"],
+        "vendorPrice": 10
+      },
+      {
+        "id": "chipped_shortsword",
+        "name": "Épée courte ébréchée",
+        "slot": "weapon",
+        "niveauMin": 1,
+        "rarity": "Commun",
+        "affixes": [
+            { "ref": "AttMin", "val": 2 },
+            { "ref": "AttMax", "val": 5 }
+        ],
+        "tagsClasse": ["berserker", "rogue"],
+        "vendorPrice": 12
+      },
+      {
+        "id": "gnarled_staff",
+        "name": "Bâton noueux",
+        "slot": "weapon",
+        "niveauMin": 1,
+        "rarity": "Commun",
+        "affixes": [
+            { "ref": "AttMin", "val": 1 },
+            { "ref": "AttMax", "val": 4 },
+            { "ref": "Intelligence", "val": 1 }
+        ],
+        "tagsClasse": ["mage", "cleric"],
+        "vendorPrice": 12
+      },
+      {
+        "id": "sturdy_iron_greaves",
+        "name": "Jambières en fer robuste",
+        "slot": "legs",
+        "niveauMin": 3,
+        "rarity": "Commun",
+        "affixes": [
+            { "ref": "Armure", "val": 12 },
+            { "ref": "Force", "val": 1 }
+        ],
+        "tagsClasse": ["berserker", "cleric"],
+        "vendorPrice": 20
+      },
+      {
+        "id": "apprentice_gloves",
+        "name": "Gants d'apprenti",
+        "slot": "hands",
+        "niveauMin": 2,
+        "rarity": "Commun",
+        "affixes": [
+            { "ref": "Armure", "val": 4 },
+            { "ref": "Intelligence", "val": 1 }
+        ],
+        "tagsClasse": ["mage", "cleric"],
+        "vendorPrice": 8
+      },
+      {
+        "id": "warriors_greathelm",
+        "name": "Grand heaume de guerrier",
+        "slot": "head",
+        "niveauMin": 5,
+        "rarity": "Rare",
+        "affixes": [
+            { "ref": "Armure", "val": 25 },
+            { "ref": "Force", "val": 3 },
+            { "ref": "PV", "val": 10 }
+        ],
+        "tagsClasse": ["berserker"],
+        "vendorPrice": 50
+      },
+      {
+        "id": "mages_circlet",
+        "name": "Cercle de mage",
+        "slot": "head",
+        "niveauMin": 5,
+        "rarity": "Rare",
+        "affixes": [
+            { "ref": "Armure", "val": 15 },
+            { "ref": "Intelligence", "val": 3 },
+            { "ref": "RessourceMax", "val": 20 }
+        ],
+        "tagsClasse": ["mage"],
+        "vendorPrice": 50
+      },
+      {
+        "id": "rogues_cowl",
+        "name": "Capuche de voleur",
+        "slot": "head",
+        "niveauMin": 5,
+        "rarity": "Rare",
+        "affixes": [
+            { "ref": "Armure", "val": 20 },
+            { "ref": "Dexterite", "val": 3 },
+            { "ref": "CritPct", "val": 1 }
+        ],
+        "tagsClasse": ["rogue"],
+        "vendorPrice": 50
+      },
+      {
+        "id": "clerics_diadem",
+        "name": "Diadème de clerc",
+        "slot": "head",
+        "niveauMin": 5,
+        "rarity": "Rare",
+        "affixes": [
+            { "ref": "Armure", "val": 18 },
+            { "ref": "Esprit", "val": 3 },
+            { "ref": "PV", "val": 10 }
+        ],
+        "tagsClasse": ["cleric"],
+        "vendorPrice": 50
+      },
+      {
         "id": "axe_of_the_deathbringer",
         "name": "Hache du Semeur de Mort",
         "slot": "weapon",

--- a/src/features/vendors/VendorsView.tsx
+++ b/src/features/vendors/VendorsView.tsx
@@ -71,7 +71,7 @@ function BuyTab() {
     };
 
     const handleBuy = (item: Item) => {
-        const success = buyItem(item);
+        const success = buyItem(item.id); // On passe maintenant juste l'ID
         if (success) {
             toast({
                 title: "Achat réussi !",
@@ -80,7 +80,7 @@ function BuyTab() {
         } else {
             toast({
                 title: "Échec de l'achat",
-                description: "Vous n&apos;avez pas assez d'or.",
+                description: "Vous n'avez pas assez d'or.",
                 variant: 'destructive'
             });
         }


### PR DESCRIPTION
This commit addresses several issues related to item generation for vendors and dungeon loot.

- Refactored `buyItem` function in `gameStore.ts` to accept an `itemId` instead of a full item object, centralizing price calculation.
- Updated `VendorsView.tsx` to align with the new `buyItem` signature.
- Improved the `endDungeon` function in `gameStore.ts` to provide more generous and guaranteed rewards, including items of higher rarity.
- Added a variety of low-level "Commun" and "Rare" items to `public/data/items.json` to serve as base templates for loot generation and vendor stock, which was the root cause of the initial problem.