### PR TITLE
feat: Enhance item naming with monster and affix themes

### DIFF
--- a/public/data/affixes.json
+++ b/public/data/affixes.json
@@ -20,6 +20,30 @@
       "type": "prefix",
       "portée": [1, 3],
       "échelonnage": "lin"
+    },
+    {
+      "id": "fire_res_1",
+      "ref": "ResElems.fire",
+      "type": "suffix",
+      "portée": [5, 15],
+      "échelonnage": "lin",
+      "theme": "fire"
+    },
+    {
+      "id": "ice_res_1",
+      "ref": "ResElems.ice",
+      "type": "suffix",
+      "portée": [5, 15],
+      "échelonnage": "lin",
+      "theme": "ice"
+    },
+    {
+      "id": "shadow_dmg_1",
+      "ref": "BonusDmg.shadow",
+      "type": "prefix",
+      "portée": [3, 10],
+      "échelonnage": "lin",
+      "theme": "shadow"
     }
   ]
 }

--- a/public/data/items.json
+++ b/public/data/items.json
@@ -4,6 +4,7 @@
         "id": "worn_leather_cap",
         "name": "Coiffe en cuir usé",
         "slot": "head",
+        "material_type": "leather",
         "niveauMin": 1,
         "rarity": "Commun",
         "affixes": [
@@ -16,6 +17,7 @@
         "id": "patched_leather_tunic",
         "name": "Tunique en cuir rapiécé",
         "slot": "chest",
+        "material_type": "leather",
         "niveauMin": 1,
         "rarity": "Commun",
         "affixes": [
@@ -29,6 +31,7 @@
         "id": "chipped_shortsword",
         "name": "Épée courte ébréchée",
         "slot": "weapon",
+        "material_type": "metal",
         "niveauMin": 1,
         "rarity": "Commun",
         "affixes": [
@@ -42,6 +45,7 @@
         "id": "gnarled_staff",
         "name": "Bâton noueux",
         "slot": "weapon",
+        "material_type": "wood",
         "niveauMin": 1,
         "rarity": "Commun",
         "affixes": [
@@ -56,6 +60,7 @@
         "id": "sturdy_iron_greaves",
         "name": "Jambières en fer robuste",
         "slot": "legs",
+        "material_type": "metal",
         "niveauMin": 3,
         "rarity": "Commun",
         "affixes": [
@@ -69,6 +74,7 @@
         "id": "apprentice_gloves",
         "name": "Gants d'apprenti",
         "slot": "hands",
+        "material_type": "cloth",
         "niveauMin": 2,
         "rarity": "Commun",
         "affixes": [
@@ -82,6 +88,7 @@
         "id": "warriors_greathelm",
         "name": "Grand heaume de guerrier",
         "slot": "head",
+        "material_type": "metal",
         "niveauMin": 5,
         "rarity": "Rare",
         "affixes": [
@@ -96,6 +103,7 @@
         "id": "mages_circlet",
         "name": "Cercle de mage",
         "slot": "head",
+        "material_type": "metal",
         "niveauMin": 5,
         "rarity": "Rare",
         "affixes": [
@@ -110,6 +118,7 @@
         "id": "rogues_cowl",
         "name": "Capuche de voleur",
         "slot": "head",
+        "material_type": "leather",
         "niveauMin": 5,
         "rarity": "Rare",
         "affixes": [
@@ -124,6 +133,7 @@
         "id": "clerics_diadem",
         "name": "Diadème de clerc",
         "slot": "head",
+        "material_type": "metal",
         "niveauMin": 5,
         "rarity": "Rare",
         "affixes": [
@@ -138,6 +148,7 @@
         "id": "axe_of_the_deathbringer",
         "name": "Hache du Semeur de Mort",
         "slot": "weapon",
+        "material_type": "metal",
         "niveauMin": 20,
         "rarity": "Légendaire",
         "affixes": [
@@ -160,6 +171,7 @@
         "id": "staff_of_the_comet_caller",
         "name": "Bâton de l'Invocateur de Comètes",
         "slot": "weapon",
+        "material_type": "wood",
         "niveauMin": 20,
         "rarity": "Légendaire",
         "affixes": [
@@ -175,6 +187,7 @@
         "id": "kingslayers_fangs",
         "name": "Crocs du Régicide",
         "slot": "weapon",
+        "material_type": "metal",
         "niveauMin": 20,
         "rarity": "Légendaire",
         "affixes": [
@@ -190,6 +203,7 @@
         "id": "hammer_of_divine_light",
         "name": "Marteau de Lumière Divine",
         "slot": "weapon",
+        "material_type": "metal",
         "niveauMin": 20,
         "rarity": "Légendaire",
         "affixes": [
@@ -205,6 +219,7 @@
         "id": "set_silver_guard_helm",
         "name": "Heaume de la Garde d'Argent",
         "slot": "head",
+        "material_type": "metal",
         "niveauMin": 10,
         "rarity": "Rare",
         "affixes": [
@@ -219,6 +234,7 @@
         "id": "set_silver_guard_chest",
         "name": "Cuirasse de la Garde d'Argent",
         "slot": "chest",
+        "material_type": "metal",
         "niveauMin": 12,
         "rarity": "Rare",
         "affixes": [
@@ -233,6 +249,7 @@
         "id": "set_arcanist_cowl",
         "name": "Capuche de l'Arcaniste",
         "slot": "head",
+        "material_type": "cloth",
         "niveauMin": 10,
         "rarity": "Rare",
         "affixes": [
@@ -247,6 +264,7 @@
         "id": "set_arcanist_robe",
         "name": "Robe de l'Arcaniste",
         "slot": "chest",
+        "material_type": "cloth",
         "niveauMin": 12,
         "rarity": "Rare",
         "affixes": [
@@ -261,6 +279,7 @@
         "id": "set_shadow_shroud_mask",
         "name": "Masque du Linceul de l'Ombre",
         "slot": "head",
+        "material_type": "leather",
         "niveauMin": 10,
         "rarity": "Rare",
         "affixes": [
@@ -275,6 +294,7 @@
         "id": "set_shadow_shroud_tunic",
         "name": "Tunique du Linceul de l'Ombre",
         "slot": "chest",
+        "material_type": "leather",
         "niveauMin": 12,
         "rarity": "Rare",
         "affixes": [
@@ -289,6 +309,7 @@
         "id": "rep_silver_vanguard_helm",
         "name": "Heaume de l'Avant-garde d'Argent",
         "slot": "head",
+        "material_type": "metal",
         "niveauMin": 25,
         "rarity": "Épique",
         "affixes": [
@@ -303,6 +324,7 @@
         "id": "rep_silver_vanguard_greataxe",
         "name": "Grande Hache de l'Avant-garde d'Argent",
         "slot": "weapon",
+        "material_type": "metal",
         "niveauMin": 30,
         "rarity": "Légendaire",
         "affixes": [
@@ -318,6 +340,7 @@
         "id": "rep_magma_callers_cowl",
         "name": "Capuche de l'Invocateur de Magma",
         "slot": "head",
+        "material_type": "cloth",
         "niveauMin": 25,
         "rarity": "Épique",
         "affixes": [
@@ -332,6 +355,7 @@
         "id": "rep_magma_callers_staff",
         "name": "Bâton de l'Invocateur de Magma",
         "slot": "weapon",
+        "material_type": "wood",
         "niveauMin": 30,
         "rarity": "Légendaire",
         "affixes": [
@@ -347,6 +371,7 @@
         "id": "rep_silent_path_mask",
         "name": "Masque du Sentier Silencieux",
         "slot": "head",
+        "material_type": "leather",
         "niveauMin": 25,
         "rarity": "Épique",
         "affixes": [
@@ -361,6 +386,7 @@
         "id": "rep_silent_path_daggers",
         "name": "Dagues du Sentier Silencieux",
         "slot": "weapon",
+        "material_type": "metal",
         "niveauMin": 30,
         "rarity": "Légendaire",
         "affixes": [
@@ -376,6 +402,7 @@
         "id": "rep_faithsworn_diadem",
         "name": "Diadème du Gardien du Serment",
         "slot": "head",
+        "material_type": "metal",
         "niveauMin": 25,
         "rarity": "Épique",
         "affixes": [
@@ -390,6 +417,7 @@
         "id": "rep_faithsworn_mace",
         "name": "Masse du Gardien du Serment",
         "slot": "weapon",
+        "material_type": "metal",
         "niveauMin": 30,
         "rarity": "Légendaire",
         "affixes": [
@@ -405,6 +433,7 @@
         "id": "dragonscale_cuirass",
         "name": "Cuirasse en Écailles de Dragon",
         "slot": "chest",
+        "material_type": "leather",
         "niveauMin": 25,
         "rarity": "Légendaire",
         "affixes": [{ "ref": "Armure", "val": 120 }, { "ref": "Force", "val": 12 }, { "ref": "PV", "val": 70 }, {"ref": "ResElems.fire", "val": 15}],
@@ -415,6 +444,7 @@
         "id": "robes_of_the_void",
         "name": "Robes du Vide",
         "slot": "chest",
+        "material_type": "cloth",
         "niveauMin": 25,
         "rarity": "Légendaire",
         "affixes": [{ "ref": "Armure", "val": 80 }, { "ref": "Intelligence", "val": 18 }, { "ref": "RessourceMax", "val": 100 }],
@@ -425,6 +455,7 @@
         "id": "wraithstalker_jerkin",
         "name": "Pourpoint de Traque-spectre",
         "slot": "chest",
+        "material_type": "leather",
         "niveauMin": 25,
         "rarity": "Légendaire",
         "affixes": [{ "ref": "Armure", "val": 100 }, { "ref": "Dexterite", "val": 18 }, { "ref": "CritPct", "val": 5 }],
@@ -435,6 +466,7 @@
         "id": "vestments_of_the_redeemer",
         "name": "Vêtements du Rédempteur",
         "slot": "chest",
+        "material_type": "cloth",
         "niveauMin": 25,
         "rarity": "Légendaire",
         "affixes": [{ "ref": "Armure", "val": 90 }, { "ref": "Esprit", "val": 18 }, { "ref": "PV", "val": 80 }],

--- a/public/data/nameModifiers.json
+++ b/public/data/nameModifiers.json
@@ -1,64 +1,63 @@
 {
-  "affixes": {
-    "Force": {
-      "prefix": "Guerrier",
-      "suffix": "du Titan"
+  "qualifiers": {
+    "damaged": { "multiplier": 0.8, "names": ["Fendu", "Abîmé", "Usé", "Ébréché"] },
+    "common": { "multiplier": 1.0, "names": ["Solide", "Fiable", "Robuste", "Commun"] },
+    "superior": { "multiplier": 1.2, "names": ["Renforcé", "Artisanal", "Supérieur", "Ouvragé"] },
+    "epic": { "multiplier": 1.4, "names": ["Royal", "Magnifique", "Épique", "Chef-d'œuvre"] },
+    "legendary": { "multiplier": 1.6, "names": ["Divin", "Légendaire", "Mythique", "Unique"] }
+  },
+  "materials": {
+    "metal": ["de Fer", "d'Acier", "de Mithril", "d'Adamantite"],
+    "leather": ["de Cuir", "de Peau", "d'Écailles de Bête"],
+    "cloth": ["de Tissu", "de Soie", "de Lin Enchanté"],
+    "wood": ["de Bois", "de Chêne", "d'If Sacré"]
+  },
+  "themes": {
+    "fire": {
+      "prefixes": ["Incandescent", "Volcanique", "Cendré", "Infernal"],
+      "suffixes": ["du Brasier", "de la Fournaise", "des Flammes Éternelles"]
     },
-    "Intelligence": {
-      "prefix": "Savant",
-      "suffix": "de l'Archimage"
+    "ice": {
+      "prefixes": ["Glacial", "Givré", "Boréal", "Polaire"],
+      "suffixes": ["du Fjord", "de la Toundra", "du Givre Mortel"]
     },
-    "Dexterite": {
-      "prefix": "Vif",
-      "suffix": "de l'Ombre"
+    "nature": {
+      "prefixes": ["Sylvestre", "Vivant", "Sauvage", "Tellurique"],
+      "suffixes": ["de la Forêt", "du Bosquet Ancien", "des Ronces"]
     },
-    "Esprit": {
-      "prefix": "Spirituel",
-      "suffix": "du Prophète"
+    "shadow": {
+      "prefixes": ["Ténébreux", "Obscur", "Funeste", "Nocturne"],
+      "suffixes": ["des Ombres", "du Crépuscule", "du Vide"]
     },
-    "PV": {
-      "prefix": "Robuste",
-      "suffix": "de Jouvence"
+    "beast": {
+      "prefixes": ["Sauvage", "Primal", "Férale"],
+      "suffixes": ["de la Griffe", "du Croc", "de la Chasse"]
     },
-    "CritPct": {
-      "prefix": "Mortel",
-      "suffix": "de la Frappe Précise"
+    "undead": {
+      "prefixes": ["Spectral", "Sépulcral", "Funeste"],
+      "suffixes": ["de la Tombe", "du Tourment", "de l'Âme en Peine"]
     },
-    "CritDmg": {
-      "prefix": "Destructeur",
-      "suffix": "de la Ruine"
-    },
-    "Vitesse": {
-      "prefix": "Rapide",
-      "suffix": "du Zéphyr"
-    },
-    "Armure": {
-      "prefix": "Blindé",
-      "suffix": "d'Indestructibilité"
+    "goblin": {
+      "prefixes": ["Bricolé", "Roublard", "Pillard"],
+      "suffixes": ["de la Combine", "du Larcin", "de la Piqure"]
     }
   },
-  "qualifiers": {
-    "Fragile": 0.7,
-    "Fendu": 0.8,
-    "Usé": 0.9,
-    "Solide": 1.0,
-    "Fiable": 1.05,
-    "Renforcé": 1.1,
-    "Artisanal": 1.15,
-    "Chef-d'œuvre": 1.25,
-    "Royal": 1.35,
-    "Divin": 1.5
+  "naming_patterns": {
+    "Commun": ["{baseName} {material}"],
+    "Magique": ["{baseName} {suffix_stat}", "{prefix_stat} {baseName}"],
+    "Rare": ["{qualifier} {baseName} {suffix_stat}"],
+    "Épique": ["{prefix_theme} {baseName} {suffix_theme}"],
+    "Légendaire": ["{qualifier} {prefix_theme} {baseName} {suffix_theme}"]
   },
-  "materials": [
-    { "level": 0, "name": "de Bois" },
-    { "level": 5, "name": "de Bronze" },
-    { "level": 10, "name": "de Cuir" },
-    { "level": 15, "name": "de Fer" },
-    { "level": 25, "name": "d'Argent" },
-    { "level": 30, "name": "d'Acier" },
-    { "level": 40, "name": "d'Or" },
-    { "level": 50, "name": "de Mithril" },
-    { "level": 60, "name": "d'Adamantite" },
-    { "level": 75, "name": "Éthéré" }
-  ]
+  "affixes": {
+    "Force": { "prefix": "Guerrier", "suffix": "du Titan" },
+    "Intelligence": { "prefix": "Savant", "suffix": "de l'Archimage" },
+    "Dexterite": { "prefix": "Vif", "suffix": "de l'Ombre" },
+    "Esprit": { "prefix": "Spirituel", "suffix": "du Prophète" },
+    "PV": { "prefix": "Robuste", "suffix": "de Jouvence" },
+    "CritPct": { "prefix": "Mortel", "suffix": "de la Frappe Précise" },
+    "CritDmg": { "prefix": "Destructeur", "suffix": "de la Ruine" },
+    "Vitesse": { "prefix": "Rapide", "suffix": "du Zéphyr" },
+    "Armure": { "prefix": "Blindé", "suffix": "d'Indestructibilité" }
+  }
 }

--- a/src/components/ItemTooltip.tsx
+++ b/src/components/ItemTooltip.tsx
@@ -8,7 +8,8 @@ import { cn } from "@/lib/utils";
 
 const rarityColorMap: Record<Rareté, string> = {
     Commun: 'text-gray-400',
-    Rare: 'text-blue-400',
+    Magique: 'text-blue-300',
+    Rare: 'text-blue-500',
     Épique: 'text-purple-500',
     Légendaire: 'text-yellow-500',
     Unique: 'text-orange-500',

--- a/src/core/itemGenerator.ts
+++ b/src/core/itemGenerator.ts
@@ -1,16 +1,28 @@
 // src/core/itemGenerator.ts
-import type { Item, Rareté, Affixe } from '@/lib/types';
+import type { Item, Rareté, Affixe, MaterialType, Theme } from '@/lib/types';
 import { v4 as uuidv4 } from 'uuid';
 import nameModifiersData from '../../public/data/nameModifiers.json';
 
-const { affixes: nameModifiers, qualifiers, materials } = nameModifiersData;
+const { qualifiers, materials, themes, naming_patterns, affixes: statNameModifiers } = nameModifiersData;
+
+// Helper function to get a random element from an array
+const getRandom = <T>(arr: T[]): T => arr[Math.floor(Math.random() * arr.length)];
 
 const rarityAffixCount: Record<Rareté, [number, number]> = {
     "Commun": [0, 1],
-    "Rare": [1, 2],
+    "Magique": [1, 2],
+    "Rare": [2, 3],
     "Épique": [3, 4],
     "Légendaire": [0, 0], // Legendary items are predefined
     "Unique": [0, 0], // Unique items are predefined
+};
+
+const rarityToQualifierMap: Record<string, keyof typeof qualifiers | null> = {
+    "Commun": "common",
+    "Rare": "superior",
+    "Épique": "epic",
+    "Légendaire": "legendary",
+    "Magique": null, // Magique rarity does not use a qualifier in its pattern
 };
 
 const scaleAffixValue = (baseValue: number, level: number): number => {
@@ -22,12 +34,10 @@ export const generateProceduralItem = (
     baseItem: Omit<Item, 'id' | 'niveauMin' | 'rarity'>,
     itemLevel: number,
     rarity: Rareté,
-    availableAffixes: Affixe[]
+    availableAffixes: Affixe[],
+    dungeonTheme?: Theme,
+    monsterFamily?: string
 ): Item => {
-    // --- Qualifier Selection and Stat Application ---
-    const qualifierNames = Object.keys(qualifiers);
-    const randomQualifierName = qualifierNames[Math.floor(Math.random() * qualifierNames.length)];
-    const qualifierMod = (qualifiers as Record<string, number>)[randomQualifierName];
 
     const newItem: Item = {
         ...baseItem,
@@ -35,18 +45,16 @@ export const generateProceduralItem = (
         niveauMin: itemLevel,
         rarity: rarity,
         affixes: [],
-        // Apply qualifier modifier to base value
-        vendorPrice: Math.round((baseItem.vendorPrice || 1) * qualifierMod),
+        vendorPrice: baseItem.vendorPrice || 1,
     };
 
-    const [minAffixes, maxAffixes] = rarityAffixCount[rarity];
+    // --- Affix Generation (from original logic) ---
+    const [minAffixes, maxAffixes] = rarityAffixCount[rarity] || [0, 0];
     const numAffixes = Math.floor(Math.random() * (maxAffixes - minAffixes + 1)) + minAffixes;
 
     if (numAffixes > 0) {
         const shuffledAffixes = [...availableAffixes].sort(() => 0.5 - Math.random());
-        const selectedAffixes = shuffledAffixes.slice(0, numAffixes);
-
-        newItem.affixes = selectedAffixes.map(affix => {
+        newItem.affixes = shuffledAffixes.slice(0, numAffixes).map(affix => {
             const [min, max] = affix.portée;
             const baseValue = Math.floor(Math.random() * (max - min + 1)) + min;
             const scaledValue = scaleAffixValue(baseValue, itemLevel);
@@ -54,30 +62,88 @@ export const generateProceduralItem = (
         });
     }
 
-    // --- Dynamic Name Generation ---
-    let finalName = `${randomQualifierName} ${newItem.name}`;
+    // --- New Intelligent Name Generation ---
 
-    // --- Material Selection ---
-    const suitableMaterial = [...materials]
-        .sort((a, b) => a.level - b.level)
-        .filter(m => m.level <= itemLevel)
-        .pop();
+    // 1. Choose a naming pattern based on rarity
+    const patterns = naming_patterns[rarity as keyof typeof naming_patterns] || ["{baseName}"];
+    let finalName = getRandom(patterns);
 
-    if (suitableMaterial) {
-        finalName = `${finalName} ${suitableMaterial.name}`;
-    }
+    // 2. Replace placeholders
+    finalName = finalName.replace('{baseName}', baseItem.name);
 
-    // --- Affix Suffix ---
-    if (newItem.affixes && newItem.affixes.length > 0 && (rarity === "Rare" || rarity === "Épique")) {
-        const primaryAffix = newItem.affixes[0];
-        const modifier = (nameModifiers as Record<string, { prefix: string, suffix: string }>)[primaryAffix.ref];
-
-        if (modifier) {
-            // Always add suffix for Rare and Epic
-            finalName = `${finalName} ${modifier.suffix}`;
+    // 2a. Replace {material}
+    if (finalName.includes('{material}')) {
+        const materialType = baseItem.material_type as keyof typeof materials;
+        if (materialType && materials[materialType]) {
+            // The new data structure doesn't have levels, so we pick a random one from the category.
+            // A future improvement could be to have sub-levels within material categories.
+            const chosenMaterial = getRandom(materials[materialType]);
+            finalName = finalName.replace('{material}', chosenMaterial);
+        } else {
+            // Fallback if material is missing
+            finalName = finalName.replace('{material}', '');
         }
     }
 
+    // 2b. Replace {qualifier}
+    if (finalName.includes('{qualifier}')) {
+        const qualifierCategory = rarityToQualifierMap[rarity];
+        if (qualifierCategory && qualifiers[qualifierCategory]) {
+            const chosenQualifier = getRandom(qualifiers[qualifierCategory].names);
+            finalName = finalName.replace('{qualifier}', chosenQualifier);
+
+            // Also adjust vendor price based on qualifier multiplier
+            const qualifierMod = qualifiers[qualifierCategory].multiplier;
+            newItem.vendorPrice = Math.round(newItem.vendorPrice! * qualifierMod);
+        } else {
+            finalName = finalName.replace('{qualifier}', '');
+        }
+    }
+
+    // 2c. Replace thematic affixes
+    let themeName: Theme | undefined = undefined;
+
+    // Priority 1: Affix-based theme
+    const affixWithTheme = (newItem.affixes || [])
+        .map(affix => availableAffixes.find(a => a.ref === affix.ref))
+        .find(affixDef => affixDef?.theme);
+
+    if (affixWithTheme) {
+        themeName = affixWithTheme.theme;
+    } else {
+        // Priority 2: Monster family theme
+        themeName = monsterFamily && themes[monsterFamily as keyof typeof themes]
+            ? monsterFamily as Theme
+            : dungeonTheme; // Priority 3: Dungeon theme
+    }
+
+    if (themeName && themes[themeName as keyof typeof themes]) {
+        const theme = themes[themeName as keyof typeof themes];
+        if (finalName.includes('{prefix_theme}')) {
+            finalName = finalName.replace('{prefix_theme}', getRandom(theme.prefixes));
+        }
+        if (finalName.includes('{suffix_theme}')) {
+            finalName = finalName.replace('{suffix_theme}', getRandom(theme.suffixes));
+        }
+    }
+
+    // 2d. Replace stat affixes
+    if (newItem.affixes && newItem.affixes.length > 0) {
+        const primaryAffixRef = newItem.affixes[0].ref as keyof typeof statNameModifiers;
+        const nameModifier = statNameModifiers[primaryAffixRef];
+
+        if (nameModifier) {
+            if (finalName.includes('{prefix_stat}')) {
+                finalName = finalName.replace('{prefix_stat}', nameModifier.prefix);
+            }
+            if (finalName.includes('{suffix_stat}')) {
+                finalName = finalName.replace('{suffix_stat}', nameModifier.suffix);
+            }
+        }
+    }
+
+    // 3. Clean up any unreplaced placeholders and extra spaces
+    finalName = finalName.replace(/{\w+}/g, '').replace(/\s+/g, ' ').trim();
     newItem.name = finalName;
 
     return newItem;

--- a/src/data/schemas.ts
+++ b/src/data/schemas.ts
@@ -2,7 +2,10 @@
 
 import { z } from "zod";
 
-export const RaretéEnum = z.enum(["Commun", "Rare", "Épique", "Légendaire", "Unique"]);
+export const RaretéEnum = z.enum(["Commun", "Magique", "Rare", "Épique", "Légendaire", "Unique"]);
+
+export const ThemeSchema = z.enum(["fire", "ice", "nature", "shadow"]);
+export type Theme = z.infer<typeof ThemeSchema>;
 
 export const StatsSchema = z.object({
   PV: z.number().int(),
@@ -28,6 +31,7 @@ export const AffixSchema = z.object({
   type: z.enum(["prefix","suffix"]),
   portée: z.tuple([z.number(), z.number()]),
   échelonnage: z.enum(["lin", "exp", "palier"]),
+  theme: ThemeSchema.optional(),
 });
 
 export const ItemSetSchema = z.object({
@@ -36,9 +40,13 @@ export const ItemSetSchema = z.object({
   bonuses: z.record(z.number(), z.string())
 });
 
+export const MaterialTypeSchema = z.enum(["metal", "leather", "cloth", "wood"]);
+export type MaterialType = z.infer<typeof MaterialTypeSchema>;
+
 export const ItemSchema = z.object({
   id: z.string(),
   name: z.string(),
+  material_type: MaterialTypeSchema.optional(),
   slot: z.enum([
     "weapon","head","chest","legs","hands","feet",
     "belt","amulet","ring","ring2","trinket","offhand", "potion"

--- a/src/features/combat/components/CombatLog.tsx
+++ b/src/features/combat/components/CombatLog.tsx
@@ -8,7 +8,8 @@ import { useGameStore } from '@/state/gameStore';
 
 const rarityColorMap: Record<Rareté, string> = {
     Commun: 'text-gray-400',
-    Rare: 'text-blue-400',
+    Magique: 'text-blue-300',
+    Rare: 'text-blue-500',
     Épique: 'text-purple-500',
     Légendaire: 'text-yellow-500',
     Unique: 'text-orange-500',

--- a/src/features/town/CraftingView.tsx
+++ b/src/features/town/CraftingView.tsx
@@ -20,7 +20,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { ForgeView } from './ForgeView';
 
 const getRarityMultiplier = (rarity: Rareté): number => {
-    const rarityMultiplier = { "Commun": 1, "Rare": 2, "Épique": 3, "Légendaire": 5, "Unique": 5 };
+    const rarityMultiplier: Record<Rareté, number> = { "Commun": 1, "Magique": 1.5, "Rare": 2, "Épique": 3, "Légendaire": 5, "Unique": 5 };
     return rarityMultiplier[rarity] || 1;
 };
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -15,6 +15,8 @@ import type {
   SkillSchema,
   ItemSetSchema,
   RecipeSchema,
+  MaterialTypeSchema,
+  ThemeSchema,
 } from '@/data/schemas';
 
 export type Rareté = z.infer<typeof RaretéEnum>;
@@ -22,9 +24,11 @@ export type Quete = z.infer<typeof QueteSchema>;
 export type Faction = z.infer<typeof FactionSchema>;
 export type Stats = z.infer<typeof StatsSchema>;
 export type Affixe = z.infer<typeof AffixSchema>;
-export type Item = z.infer<typeof ItemSchema> & { vendorPrice?: number };
+export type Item = z.infer<typeof ItemSchema>;
 export type Skill = z.infer<typeof SkillSchema>;
 export type Talent = z.infer<typeof TalentSchema>;
+export type MaterialType = z.infer<typeof MaterialTypeSchema>;
+export type Theme = z.infer<typeof ThemeSchema>;
 export type Monstre = z.infer<typeof MonsterSchema> & { id: string };
 export type Dungeon = z.infer<typeof DungeonSchema>;
 export type Classe = z.infer<typeof ClasseSchema>;


### PR DESCRIPTION
This commit adds more contextual layers to the item naming system.

- Expands `nameModifiers.json` with themes for monster families (beast, undead, etc.).
- Updates the item generation logic to prioritize themes based on a clear hierarchy:
  1. Item Affix Theme
  2. Monster Family Theme
  3. Dungeon Biome Theme
- Adds a `theme` property to the affix data structure to enable this linkage.
- Updates all relevant function signatures and call sites to pass the necessary contextual data (e.g., `monsterFamily`).
- Confirmed that a system for unique boss loot drops is already in place.