### PR TITLE
feat: Finalize item generation rework and fix stat display

### DIFF
--- a/src/components/ItemTooltip.tsx
+++ b/src/components/ItemTooltip.tsx
@@ -5,6 +5,7 @@ import { Popover, PopoverTrigger, PopoverContent } from "./ui/popover";
 import { Item, Rareté, Stats } from "@/lib/types";
 import { Separator } from "./ui/separator";
 import { cn } from "@/lib/utils";
+import { STAT_DISPLAY_NAMES } from "@/lib/constants";
 
 const rarityColorMap: Record<Rareté, string> = {
     Commun: 'text-gray-400',
@@ -139,7 +140,7 @@ export function ItemTooltipContent({ item, equippedItem }: { item: Item, equippe
                 {allSortedAffixes.map((affix) => (
                     <ItemStat 
                         key={affix.ref}
-                        label={affix.ref}
+                        label={STAT_DISPLAY_NAMES[affix.ref] || affix.ref}
                         value={`${affix.val > 0 ? '+' : ''}${affix.val}`}
                         comparison={comparisonStats[affix.ref as StatKey]}
                     />

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -3,3 +3,25 @@ import type { InventoryState } from './types';
 export const EQUIPMENT_SLOTS: (keyof InventoryState['equipment'])[] = [
     'head', 'chest', 'legs', 'feet', 'hands', 'weapon', 'offhand', 'amulet', 'ring', 'ring2', 'belt', 'trinket'
 ];
+
+export const STAT_DISPLAY_NAMES: Record<string, string> = {
+    'Force': 'Force',
+    'Dexterite': 'Dextérité',
+    'Intelligence': 'Intelligence',
+    'Esprit': 'Esprit',
+    'PV': 'Points de Vie',
+    'CritPct': '% de Critique',
+    'CritDmg': 'Dégâts Critiques',
+    'Vitesse': "Vitesse d'Attaque",
+    'Armure': 'Armure',
+    'RessourceMax': 'Ressource Max',
+    'Esquive': 'Esquive',
+    'AttMin': 'Dégâts Min',
+    'AttMax': 'Dégâts Max',
+    'Precision': 'Précision',
+    'ResElems.fire': 'Résistance Feu',
+    'ResElems.ice': 'Résistance Glace',
+    'ResElems.shadow': 'Résistance Ombre',
+    'ResElems.nature': 'Résistance Nature',
+    'BonusDmg.shadow': "Dégâts d'Ombre",
+};


### PR DESCRIPTION
This commit completes the overhaul of the item generation system based on user feedback and fixes a stat display bug.

- Implements a stat name mapping in `constants.ts` and updates `ItemTooltip.tsx` to display user-friendly names instead of internal keys (e.g., "Résistance Glace" instead of "ResElems.ice").
- Replaces the item generation logic in `itemGenerator.ts` with a new, more robust implementation provided by the user.
- Updates all data files (`nameModifiers.json`, `items.json`, `monsters.json`) with new content and structures as per user request, including a new boss, new loot, and simplified base names.
- Increases the boss loot drop chance to 25%.
- All changes have been type-checked and are consistent with the application's structure.