### PR TITLE
Fix multiple gameplay bugs and inconsistencies

### DIFF
--- a/public/data/nameModifiers.json
+++ b/public/data/nameModifiers.json
@@ -41,15 +41,15 @@
   "naming_patterns": {
     "Rare": [
       "{baseName} {suffix}",
-      "{prefix} {baseName}"
+      "{baseName} {prefix}"
     ],
     "Épique": [
-      "{prefix} {baseName} {suffix}",
+      "{baseName} {prefix} {suffix}",
       "{qualifier} {baseName} {suffix}"
     ],
     "Légendaire": [
-        "{prefix} {baseName} {suffix}",
-        "{qualifier} {prefix} {baseName}",
+        "{baseName} {prefix} {suffix}",
+        "{qualifier} {baseName} {prefix}",
         "{qualifier} {baseName} {suffix}"
     ]
   },

--- a/public/data/skills.json
+++ b/public/data/skills.json
@@ -539,6 +539,19 @@
             "effets": [
                 "Enduit vos armes d'un poison qui a 30% de chances d'infliger 5 dégâts de Nature. Dure 1 heure.",
                 "Coûte 10 Énergie."
+            ],
+            "effects": [
+                {
+                    "type": "buff",
+                    "id": "deadly_poison_buff",
+                    "name": "Poison mortel",
+                    "duration": 3600,
+                    "buffType": "special"
+                },
+                {
+                    "type": "resource_cost",
+                    "amount": 10
+                }
             ]
         },
         {

--- a/src/core/itemGenerator.ts
+++ b/src/core/itemGenerator.ts
@@ -49,6 +49,15 @@ export const generateProceduralItem = (
     dungeonTheme?: string, // Optional: to link the name to the dungeon
     monsterTheme?: string // Optional: to link the name to the monster family
 ): Item => {
+    if (baseItem.type === 'quest') {
+        return {
+            ...baseItem,
+            id: uuidv4(),
+            niveauMin: itemLevel,
+            rarity: rarity,
+        };
+    }
+
     const qualifierCategoryKey = rarityToQualifierKey[rarity] || 'common';
     const qualifierCategory = (qualifiers as any)[qualifierCategoryKey];
     const qualifierMultiplier = qualifierCategory ? qualifierCategory.multiplier : 1.0;


### PR DESCRIPTION
This commit addresses several issues reported by the user:

- **XP and Level-Up Bug:** The level-up logic was only triggered after killing a monster, not after receiving XP from other sources like dungeon or quest completion. This has been fixed by refactoring the level-up logic into a reusable `checkAndApplyLevelUp` function, which is now called whenever the player gains XP.

- **Quest Completion Bug:** The "Nettoyage de Goblin Mines" quest, and other quests of type `nettoyage` (clear), were not completing. This was because there was no logic to check for these quests upon dungeon completion. The `endDungeon` function has been updated to check for and complete these quests.

- **"Poison mortel du voleur" Skill Not Working:** The "Poison mortel du voleur" (Rogue's Deadly Poison) skill was not functional because it was missing its `effects` block in the data file. The skill has been updated with the correct effects, and the `playerAttack` function now includes the logic for the poison to proc.

- **Equipment Naming Inconsistencies:** Several item names were grammatically incorrect in French (e.g., "Puissant Tunique rapiécée" instead of "Tunique rapiécée puissante"). This was caused by incorrect naming patterns. The patterns in `public/data/nameModifiers.json` have been corrected to place adjectives after the noun.

- **Quest Item Naming:** Quest items were sometimes getting procedural affixes. A check has been added to the item generator to prevent this.

- **Dodge Mechanic Clarification:** Added a comment to the code to confirm that the dodge (`esquive`) mechanic is implemented and working as intended.