### PR TITLE
feat: Implement combat log viewer and fix multiple bugs

### DIFF
--- a/src/data/schemas.ts
+++ b/src/data/schemas.ts
@@ -1,6 +1,7 @@
 // src/data/schemas.ts
 
 import { z } from "zod";
+import { CombatLogEntry } from "@/lib/types";
 
 export const RaretéEnum = z.enum(["Commun", "Magique", "Rare", "Épique", "Légendaire", "Unique"]);
 
@@ -320,4 +321,5 @@ export interface DungeonCompletionSummary {
         gold: number;
         items: Item[];
     };
+    combatLog: CombatLogEntry[];
 }

--- a/src/features/combat/components/CombatLog.tsx
+++ b/src/features/combat/components/CombatLog.tsx
@@ -35,6 +35,8 @@ const getLogEntryColor = (type: CombatLogEntry['type']) => {
       return 'text-emerald-400';
     case 'shield':
       return 'text-cyan-400';
+    case 'poison_proc':
+      return 'text-lime-400';
     default:
       return 'text-foreground';
   }

--- a/src/state/gameStore.ts
+++ b/src/state/gameStore.ts
@@ -1259,6 +1259,7 @@ export const useGameStore = create<GameState>()(
                 itemsGained: [...combat.dungeonRunItems],
                 chestRewards: chestRewards,
                 recipesGained: [],
+                combatLog: combat.log,
             };
 
             // --- Bonus Recipe Drop from Chest ---
@@ -1279,7 +1280,6 @@ export const useGameStore = create<GameState>()(
             state.dungeonCompletionSummary = summary;
 
             inventory.gold += summary.goldGained + (summary.chestRewards?.gold ?? 0);
-            player.xp += summary.xpGained;
             inventory.items.push(...summary.itemsGained);
             if (summary.chestRewards) {
                 inventory.items.push(...summary.chestRewards.items);
@@ -1603,7 +1603,7 @@ export const useGameStore = create<GameState>()(
             if (player.activeBuffs.some(b => b.id === 'deadly_poison_buff') && Math.random() < 0.3) {
                 const poisonDamage = 5; // As per skill description
                 target.stats.PV -= poisonDamage;
-                combat.log.push({ message: `Your Deadly Poison deals an additional ${poisonDamage} damage to ${target.nom}.`, type: 'player_attack', timestamp: Date.now() });
+                combat.log.push({ message: `Your Deadly Poison deals an additional ${poisonDamage} damage to ${target.nom}.`, type: 'poison_proc', timestamp: Date.now() });
             }
 
             const attackMsg = `You hit ${target.nom} for ${mitigatedDamage} damage.`;
@@ -2212,7 +2212,7 @@ export const useGameStore = create<GameState>()(
             state.combat.log.push({ message: `You find ${goldDrop} gold.`, type: 'loot', timestamp: Date.now() });
             state.combat.goldGained += goldDrop;
 
-            state.combat.xpGained += xpGained;
+            state.player.xp += xpGained;
             state.combat.log.push({ message: `You gain ${xpGained} experience.`, type: 'info', timestamp: Date.now() });
 
             if (state.dungeonState && state.dungeonState.equipmentDropsPending > 0 && state.dungeonState.monstersRemainingInDungeon > 0) {


### PR DESCRIPTION
This commit includes a wide range of fixes and features to improve the game experience.

Bug Fixes:
- **Item Naming:** Corrected the grammatical order for item names with prefixes (e.g., "Puissant Tunique" is now "Tunique puissante") by updating `nameModifiers.json`.
- **Quest Item Affixes:** Prevented quest-specific items like "Croc de chauve-souris" from getting random affixes by adding a check in the item generator.
- **Quest Completion:** Fixed a bug where `nettoyage` (clearing) type quests, such as "Nettoyage de Goblin Mines," were not completing. The `endDungeon` function now correctly checks for and rewards these quests.
- **XP & Leveling:** Resolved a critical bug where player XP would not apply correctly, preventing level-ups. A centralized `checkAndApplyLevelUp` function has been created and is now called whenever XP is gained, ensuring consistent progression.
- **Live XP Updates:** XP gained from monster kills during a dungeon now updates the player's total XP in real-time.

Features & Enhancements:
- **Rogue's Deadly Poison:** Implemented the previously non-functional "Poison mortel du voleur" skill. It now applies a buff that gives the Rogue's attacks a 30% chance to deal additional poison damage.
- **Poison Proc Visuals:** Added a distinct visual style (`poison_proc`) for the poison damage in the combat log to make it more noticeable.
- **Full Combat Log Viewer:** Added a button on the dungeon completion screen to open a dialog displaying the full, scrollable combat log from the run.