### PR TITLE
feat: Implement prioritized game logic and refactor heroic dungeons

### DIFF
--- a/public/data/dungeons.json
+++ b/public/data/dungeons.json
@@ -2,6 +2,7 @@
     "dungeons": [
         {
             "id": "dungeon_1",
+            "heroicVersionId": "dungeon_1_heroic",
             "palier": 1,
             "name": "Goblin Mines",
             "biome": "shadow",
@@ -15,6 +16,7 @@
         },
         {
             "id": "dungeon_2",
+            "heroicVersionId": "dungeon_2_heroic",
             "palier": 1,
             "name": "Bat Cave",
             "biome": "shadow",
@@ -28,6 +30,7 @@
         },
         {
             "id": "dungeon_3",
+            "heroicVersionId": "dungeon_3_heroic",
             "palier": 2,
             "name": "Icy Crevasse",
             "biome": "ice",
@@ -42,6 +45,7 @@
         },
         {
             "id": "dungeon_4",
+            "heroicVersionId": "dungeon_4_heroic",
             "palier": 2,
             "name": "Yeti Den",
             "biome": "ice",
@@ -56,6 +60,7 @@
         },
         {
             "id": "dungeon_5",
+            "heroicVersionId": "dungeon_5_heroic",
             "palier": 3,
             "name": "Scorched Caverns",
             "biome": "fire",
@@ -70,6 +75,7 @@
         },
         {
             "id": "dungeon_6",
+            "heroicVersionId": "dungeon_6_heroic",
             "palier": 3,
             "name": "Cinder Chambers",
             "biome": "fire",
@@ -84,6 +90,7 @@
         },
         {
             "id": "dungeon_7",
+            "heroicVersionId": "dungeon_7_heroic",
             "palier": 4,
             "name": "Whispering Woods",
             "biome": "nature",
@@ -98,6 +105,7 @@
         },
         {
             "id": "dungeon_8",
+            "heroicVersionId": "dungeon_8_heroic",
             "palier": 4,
             "name": "Dryad Grove",
             "biome": "nature",
@@ -112,6 +120,7 @@
         },
         {
             "id": "dungeon_9",
+            "heroicVersionId": "dungeon_9_heroic",
             "palier": 5,
             "name": "Forgotten Crypt",
             "biome": "shadow",
@@ -127,6 +136,7 @@
         },
         {
             "id": "dungeon_10",
+            "heroicVersionId": "dungeon_10_heroic",
             "palier": 5,
             "name": "Void Worshippers' Lair",
             "biome": "shadow",
@@ -142,6 +152,7 @@
         },
         {
             "id": "dungeon_11",
+            "heroicVersionId": "dungeon_11_heroic",
             "palier": 6,
             "name": "Glacial Depths",
             "biome": "ice",
@@ -157,6 +168,7 @@
         },
         {
             "id": "dungeon_12",
+            "heroicVersionId": "dungeon_12_heroic",
             "palier": 6,
             "name": "Frozen Berserkers' Hall",
             "biome": "ice",
@@ -172,6 +184,7 @@
         },
         {
             "id": "dungeon_13",
+            "heroicVersionId": "dungeon_13_heroic",
             "palier": 7,
             "name": "Volcanic Core",
             "biome": "fire",
@@ -187,6 +200,7 @@
         },
         {
             "id": "dungeon_14",
+            "heroicVersionId": "dungeon_14_heroic",
             "palier": 7,
             "name": "Fire Giants' Outpost",
             "biome": "fire",
@@ -202,6 +216,7 @@
         },
         {
             "id": "dungeon_15",
+            "heroicVersionId": "dungeon_15_heroic",
             "palier": 8,
             "name": "Verdant Labyrinth",
             "biome": "nature",
@@ -217,6 +232,7 @@
         },
         {
             "id": "dungeon_16",
+            "heroicVersionId": "dungeon_16_heroic",
             "palier": 8,
             "name": "Sylvan Guardians' Domain",
             "biome": "nature",
@@ -232,6 +248,7 @@
         },
         {
             "id": "dungeon_17",
+            "heroicVersionId": "dungeon_17_heroic",
             "palier": 9,
             "name": "Shadowy Necropolis",
             "biome": "shadow",
@@ -248,6 +265,7 @@
         },
         {
             "id": "dungeon_18",
+            "heroicVersionId": "dungeon_18_heroic",
             "palier": 9,
             "name": "Specters' Sanctuary",
             "biome": "shadow",
@@ -264,6 +282,7 @@
         },
         {
             "id": "dungeon_19",
+            "heroicVersionId": "dungeon_19_heroic",
             "palier": 10,
             "name": "Frozen Wastes",
             "biome": "ice",
@@ -280,6 +299,7 @@
         },
         {
             "id": "dungeon_20",
+            "heroicVersionId": "dungeon_20_heroic",
             "palier": 10,
             "name": "Boreal Knights' Fortress",
             "biome": "ice",
@@ -296,6 +316,7 @@
         },
         {
             "id": "dungeon_21",
+            "heroicVersionId": "dungeon_21_heroic",
             "palier": 11,
             "name": "Infernal Forge",
             "biome": "fire",
@@ -312,6 +333,7 @@
         },
         {
             "id": "dungeon_22",
+            "heroicVersionId": "dungeon_22_heroic",
             "palier": 11,
             "name": "Ash Harpies' Nest",
             "biome": "fire",
@@ -328,6 +350,7 @@
         },
         {
             "id": "dungeon_23",
+            "heroicVersionId": "dungeon_23_heroic",
             "palier": 12,
             "name": "Emerald Nightmare",
             "biome": "nature",
@@ -344,6 +367,7 @@
         },
         {
             "id": "dungeon_24",
+            "heroicVersionId": "dungeon_24_heroic",
             "palier": 12,
             "name": "Emerald Golems' Garden",
             "biome": "nature",
@@ -360,6 +384,7 @@
         },
         {
             "id": "dungeon_25",
+            "heroicVersionId": "dungeon_25_heroic",
             "palier": 13,
             "name": "Cathedral of Eternal Night",
             "biome": "shadow",
@@ -377,6 +402,7 @@
         },
         {
             "id": "dungeon_26",
+            "heroicVersionId": "dungeon_26_heroic",
             "palier": 13,
             "name": "Tomb Guardians' Crypt",
             "biome": "shadow",
@@ -394,6 +420,7 @@
         },
         {
             "id": "dungeon_27",
+            "heroicVersionId": "dungeon_27_heroic",
             "palier": 14,
             "name": "Glacier's Peak",
             "biome": "ice",
@@ -411,6 +438,7 @@
         },
         {
             "id": "dungeon_28",
+            "heroicVersionId": "dungeon_28_heroic",
             "palier": 14,
             "name": "Frost Wyrm's Lair",
             "biome": "ice",
@@ -428,6 +456,7 @@
         },
         {
             "id": "dungeon_29",
+            "heroicVersionId": "dungeon_29_heroic",
             "palier": 15,
             "name": "Heart of the Volcano",
             "biome": "fire",
@@ -445,6 +474,7 @@
         },
         {
             "id": "dungeon_30",
+            "heroicVersionId": "dungeon_30_heroic",
             "palier": 15,
             "name": "Magma Dragon's Roost",
             "biome": "fire",
@@ -462,6 +492,7 @@
         },
         {
             "id": "dungeon_31",
+            "heroicVersionId": "dungeon_31_heroic",
             "palier": 16,
             "name": "Throne of the Wilds",
             "biome": "nature",
@@ -479,6 +510,7 @@
         },
         {
             "id": "dungeon_32",
+            "heroicVersionId": "dungeon_32_heroic",
             "palier": 16,
             "name": "World Ash Treant's Grove",
             "biome": "nature",
@@ -496,6 +528,7 @@
         },
         {
             "id": "dungeon_33",
+            "heroicVersionId": "dungeon_33_heroic",
             "palier": 17,
             "name": "The Void-Corrupted Sanctum",
             "biome": "shadow",
@@ -514,6 +547,7 @@
         },
         {
             "id": "dungeon_34",
+            "heroicVersionId": "dungeon_34_heroic",
             "palier": 17,
             "name": "Cthulhu's Herald's Antechamber",
             "biome": "shadow",
@@ -532,6 +566,7 @@
         },
         {
             "id": "dungeon_35",
+            "heroicVersionId": "dungeon_35_heroic",
             "palier": 18,
             "name": "Permafrost Citadel",
             "biome": "ice",
@@ -547,6 +582,7 @@
         },
         {
             "id": "dungeon_36",
+            "heroicVersionId": "dungeon_36_heroic",
             "palier": 18,
             "name": "Molten Pinnacle",
             "biome": "fire",
@@ -562,6 +598,7 @@
         },
         {
             "id": "dungeon_37",
+            "heroicVersionId": "dungeon_37_heroic",
             "palier": 19,
             "name": "Heart of the Forest",
             "biome": "nature",
@@ -577,6 +614,7 @@
         },
         {
             "id": "dungeon_38",
+            "heroicVersionId": "dungeon_38_heroic",
             "palier": 19,
             "name": "R'lyeh's Threshold",
             "biome": "shadow",
@@ -592,6 +630,7 @@
         },
         {
             "id": "dungeon_39",
+            "heroicVersionId": "dungeon_39_heroic",
             "palier": 20,
             "name": "Frozen Throne",
             "biome": "ice",
@@ -608,6 +647,7 @@
         },
         {
             "id": "dungeon_40",
+            "heroicVersionId": "dungeon_40_heroic",
             "palier": 20,
             "name": "Inferno's Core",
             "biome": "fire",
@@ -624,6 +664,7 @@
         },
         {
             "id": "dungeon_41",
+            "heroicVersionId": "dungeon_41_heroic",
             "palier": 21,
             "name": "Verdant Sanctuary",
             "biome": "nature",
@@ -640,6 +681,7 @@
         },
         {
             "id": "dungeon_42",
+            "heroicVersionId": "dungeon_42_heroic",
             "palier": 21,
             "name": "The Sunken City",
             "biome": "shadow",
@@ -656,6 +698,7 @@
         },
         {
             "id": "dungeon_43",
+            "heroicVersionId": "dungeon_43_heroic",
             "palier": 22,
             "name": "Icecrown Citadel",
             "biome": "ice",
@@ -673,6 +716,7 @@
         },
         {
             "id": "dungeon_44",
+            "heroicVersionId": "dungeon_44_heroic",
             "palier": 22,
             "name": "Blackrock Mountain",
             "biome": "fire",
@@ -690,6 +734,7 @@
         },
         {
             "id": "dungeon_45",
+            "heroicVersionId": "dungeon_45_heroic",
             "palier": 23,
             "name": "The Emerald Dream",
             "biome": "nature",
@@ -707,6 +752,7 @@
         },
         {
             "id": "dungeon_46",
+            "heroicVersionId": "dungeon_46_heroic",
             "palier": 23,
             "name": "Ny'alotha, the Waking City",
             "biome": "shadow",
@@ -724,6 +770,7 @@
         },
         {
             "id": "dungeon_47",
+            "heroicVersionId": "dungeon_47_heroic",
             "palier": 24,
             "name": "The Frozen Halls",
             "biome": "ice",
@@ -742,6 +789,7 @@
         },
         {
             "id": "dungeon_48",
+            "heroicVersionId": "dungeon_48_heroic",
             "palier": 25,
             "name": "The Molten Core",
             "biome": "fire",

--- a/public/data/monsters.json
+++ b/public/data/monsters.json
@@ -28,7 +28,11 @@
             "level": 3,
             "isBoss": true,
             "palier": 1,
-            "stats": { "PV": 150, "AttMin": 12, "AttMax": 18, "CritPct": 10, "CritDmg": 150, "Armure": 50, "Vitesse": 2.5, "Precision": 65, "Esquive": 5 }
+            "stats": { "PV": 150, "AttMin": 12, "AttMax": 18, "CritPct": 10, "CritDmg": 150, "Armure": 50, "Vitesse": 2.5, "Precision": 65, "Esquive": 5 },
+            "abilities": [{
+                "id": "get_back_to_work", "name": "Au travail !", "cooldown": 15, "chance": 0.3,
+                "effects": [{ "type": "debuff", "debuffType": "cc", "id": "supervisor_stun", "name": "Intimidation", "duration": 1.5, "ccType": "stun" }]
+            }]
         },
         {
             "id": "kobold_miner_assistant",
@@ -206,7 +210,27 @@
             "famille": "Undead",
             "isBoss": false,
             "palier": 6,
-            "stats": { "PV": 400, "AttMin": 70, "AttMax": 85, "CritPct": 12, "CritDmg": 160, "Armure": 150, "Vitesse": 2.2, "Precision": 90, "Esquive": 22 }
+            "stats": { "PV": 400, "AttMin": 70, "AttMax": 85, "CritPct": 12, "CritDmg": 160, "Armure": 150, "Vitesse": 2.2, "Precision": 90, "Esquive": 22 },
+            "abilities": [
+                {
+                    "id": "monster_frost_attack",
+                    "name": "Attaque de givre",
+                    "cooldown": 10,
+                    "chance": 0.5,
+                    "effects": [
+                        {
+                            "type": "debuff",
+                            "debuffType": "stat_modifier",
+                            "id": "monster_frost_slow",
+                            "name": "Ralentissement glacial",
+                            "duration": 6,
+                            "statMods": [
+                                { "stat": "Vitesse", "modifier": "multiplicative", "value": 1.30 }
+                            ]
+                        }
+                    ]
+                }
+            ]
         },
         {
             "id": "frozen_berserker",
@@ -233,7 +257,29 @@
             "famille": "Beast",
             "isBoss": false,
             "palier": 7,
-            "stats": { "PV": 550, "AttMin": 76, "AttMax": 90, "CritPct": 15, "CritDmg": 170, "Armure": 280, "Vitesse": 2.3, "Precision": 90, "Esquive": 18 }
+            "stats": { "PV": 550, "AttMin": 76, "AttMax": 90, "CritPct": 15, "CritDmg": 170, "Armure": 280, "Vitesse": 2.3, "Precision": 90, "Esquive": 18 },
+            "abilities": [
+                {
+                    "id": "monster_fire_breath",
+                    "name": "Souffle de feu",
+                    "cooldown": 12,
+                    "chance": 0.4,
+                    "effects": [
+                        {
+                            "type": "debuff",
+                            "debuffType": "dot",
+                            "id": "monster_fire_dot",
+                            "name": "Brûlure infernale",
+                            "duration": 9,
+                            "damageType": "fire",
+                            "totalDamage": {
+                                "source": "base_value",
+                                "multiplier": 45
+                            }
+                        }
+                    ]
+                }
+            ]
         },
         {
             "id": "obsidian_gargoyle",
@@ -536,7 +582,8 @@
             "famille": "Dragonkin",
             "isBoss": true,
             "palier": 14,
-            "stats": { "PV": 12000, "AttMin": 360, "AttMax": 405, "CritPct": 15, "CritDmg": 180, "Armure": 2500, "Vitesse": 3, "Precision": 120, "Esquive": 15 }
+            "stats": { "PV": 12000, "AttMin": 360, "AttMax": 405, "CritPct": 15, "CritDmg": 180, "Armure": 2500, "Vitesse": 3, "Precision": 120, "Esquive": 15 },
+            "abilities": [{"id": "deep_freeze", "name": "Gelure profonde", "cooldown": 20, "chance": 0.3, "effects": [{ "type": "debuff", "debuffType": "cc", "id": "deep_freeze_stun", "name": "Gelé", "duration": 4, "ccType": "stun" }] }]
         },
         {
             "id": "ice_titan",
@@ -590,7 +637,8 @@
             "famille": "Dragonkin",
             "isBoss": true,
             "palier": 15,
-            "stats": { "PV": 14400, "AttMin": 405, "AttMax": 450, "CritPct": 15, "CritDmg": 180, "Armure": 2800, "Vitesse": 3, "Precision": 125, "Esquive": 15 }
+            "stats": { "PV": 14400, "AttMin": 405, "AttMax": 450, "CritPct": 15, "CritDmg": 180, "Armure": 2800, "Vitesse": 3, "Precision": 125, "Esquive": 15 },
+            "abilities": [{"id": "magma_breath", "name": "Souffle de Magma", "cooldown": 20, "chance": 0.5, "effects": [{ "type": "damage", "damageType": "fire", "multiplier": 1.5 }, { "type": "debuff", "debuffType": "vulnerability", "id": "magma_vuln", "name": "Armure fondue", "duration": 10, "damageType": "all", "multiplier": 1.15 }] }]
         },
         {
             "id": "balrog",
@@ -644,7 +692,8 @@
             "famille": "Plant",
             "isBoss": true,
             "palier": 16,
-            "stats": { "PV": 20000, "AttMin": 495, "AttMax": 540, "CritPct": 10, "CritDmg": 160, "Armure": 4000, "Vitesse": 4.5, "Precision": 130, "Esquive": 10 }
+            "stats": { "PV": 20000, "AttMin": 495, "AttMax": 540, "CritPct": 10, "CritDmg": 160, "Armure": 4000, "Vitesse": 4.5, "Precision": 130, "Esquive": 10 },
+            "abilities": [{"id": "ashes_of_the_world", "name": "Cendres du Monde", "cooldown": 25, "chance": 0.4, "effects": [{ "type": "buff", "buffType": "stat_modifier", "id": "world_ash_dmg_buff", "name": "Puissance des cendres", "duration": 15, "statMods": [{ "stat": "AttMin", "modifier": "multiplicative", "value": 1.25 }, { "stat": "AttMax", "modifier": "multiplicative", "value": 1.25 }] }, { "type": "debuff", "debuffType": "dot", "id": "world_ash_aura", "name": "Aura de cendres", "duration": 15, "damageType": "fire", "totalDamage": { "source": "base_value", "multiplier": 350 } }] }]
         },
         {
             "id": "gaia_avatar",
@@ -698,7 +747,8 @@
             "famille": "Aberration",
             "isBoss": true,
             "palier": 17,
-            "stats": { "PV": 32000, "AttMin": 720, "AttMax": 810, "CritPct": 20, "CritDmg": 200, "Armure": 4500, "Vitesse": 2.8, "Precision": 160, "Esquive": 25 }
+            "stats": { "PV": 32000, "AttMin": 720, "AttMax": 810, "CritPct": 20, "CritDmg": 200, "Armure": 4500, "Vitesse": 2.8, "Precision": 160, "Esquive": 25 },
+            "abilities": [{"id": "touch_of_the_void", "name": "Toucher du Vide", "cooldown": 18, "chance": 0.5, "effects": [{ "type": "damage", "damageType": "shadow", "multiplier": 1.4 }, { "type": "debuff", "debuffType": "stat_modifier", "id": "insanity_debuff", "name": "Folie", "duration": 12, "statMods": [{ "stat": "Precision", "modifier": "multiplicative", "value": 0.75 }, { "stat": "Esquive", "modifier": "multiplicative", "value": 0.75 }] }] }]
         },
         {
             "id": "archlich_of_nar'thalas",
@@ -761,7 +811,11 @@
             "famille": "Beast",
             "isBoss": true,
             "palier": 1,
-            "stats": { "PV": 200, "AttMin": 15, "AttMax": 22, "CritPct": 12, "CritDmg": 150, "Armure": 40, "Vitesse": 2.0, "Precision": 70, "Esquive": 20 }
+            "stats": { "PV": 200, "AttMin": 15, "AttMax": 22, "CritPct": 12, "CritDmg": 150, "Armure": 40, "Vitesse": 2.0, "Precision": 70, "Esquive": 20 },
+            "abilities": [{
+                "id": "piercing_screech", "name": "Cri perçant", "cooldown": 12, "chance": 0.4,
+                "effects": [{ "type": "debuff", "debuffType": "stat_modifier", "id": "screech_armor_down", "name": "Armure brisée", "duration": 8, "statMods": [{ "stat": "Armure", "modifier": "multiplicative", "value": 0.85 }] }]
+            }]
         },
         {
             "id": "yeti_chieftain",
@@ -771,6 +825,13 @@
             "isBoss": true,
             "palier": 2,
             "stats": { "PV": 600, "AttMin": 25, "AttMax": 35, "CritPct": 8, "CritDmg": 150, "Armure": 150, "Vitesse": 3.2, "Precision": 75, "Esquive": 10 },
+            "abilities": [{
+                "id": "ground_slam", "name": "Frappe assommante", "cooldown": 10, "chance": 0.5,
+                "effects": [
+                    { "type": "damage", "damageType": "physical", "multiplier": 1.5 },
+                    { "type": "debuff", "debuffType": "cc", "id": "slam_stun", "name": "Assommé", "duration": 2, "ccType": "stun" }
+                ]
+            }],
             "specificLootTable": ["axe_of_the_deathbringer", "set_silver_guard_helm", "set_silver_guard_chest"],
             "componentLoot": [
                 { "id": "frozen_heart", "chance": 0.25, "quantity": 1 }
@@ -784,6 +845,10 @@
             "isBoss": true,
             "palier": 3,
             "stats": { "PV": 800, "AttMin": 45, "AttMax": 55, "CritPct": 10, "CritDmg": 150, "Armure": 180, "Vitesse": 2.7, "Precision": 80, "Esquive": 12, "ResElems": { "fire": 40, "ice": -20 } },
+            "abilities": [{
+                "id": "immolation", "name": "Immolation", "cooldown": 12, "chance": 0.5,
+                "effects": [{ "type": "debuff", "debuffType": "dot", "id": "immolation_dot", "name": "Immolation", "duration": 6, "damageType": "fire", "totalDamage": { "source": "base_value", "multiplier": 90 } }]
+            }],
             "specificLootTable": ["set_arcanist_cowl", "set_arcanist_robe"],
             "recipeLoot": [
                 { "id": "enchant_superior_fire_resistance", "chance": 0.1, "quantity": 1 }
@@ -797,6 +862,10 @@
             "isBoss": true,
             "palier": 4,
             "stats": { "PV": 1200, "AttMin": 60, "AttMax": 75, "CritPct": 15, "CritDmg": 160, "Armure": 250, "Vitesse": 2.4, "Precision": 85, "Esquive": 18 },
+            "abilities": [{
+                "id": "barkskin", "name": "Écorcefer", "cooldown": 20, "chance": 0.3,
+                "effects": [{ "type": "buff", "buffType": "stat_modifier", "id": "barkskin_buff", "name": "Écorcefer", "duration": 10, "statMods": [{ "stat": "Armure", "modifier": "multiplicative", "value": 2.0 }] }]
+            }],
             "specificLootTable": ["set_shadow_shroud_mask", "set_shadow_shroud_tunic"]
         },
         {
@@ -806,7 +875,11 @@
             "famille": "Humanoid",
             "isBoss": true,
             "palier": 5,
-            "stats": { "PV": 1800, "AttMin": 70, "AttMax": 85, "CritPct": 12, "CritDmg": 150, "Armure": 350, "Vitesse": 2.8, "Precision": 90, "Esquive": 14 }
+            "stats": { "PV": 1800, "AttMin": 70, "AttMax": 85, "CritPct": 12, "CritDmg": 150, "Armure": 350, "Vitesse": 2.8, "Precision": 90, "Esquive": 14 },
+            "abilities": [{
+                "id": "void_bolt", "name": "Trait du Vide", "cooldown": 8, "chance": 0.6,
+                "effects": [{ "type": "damage", "damageType": "shadow", "multiplier": 1.2 }]
+            }]
         },
         {
             "id": "void_priest",
@@ -815,7 +888,11 @@
             "famille": "Humanoid",
             "isBoss": true,
             "palier": 5,
-            "stats": { "PV": 1900, "AttMin": 75, "AttMax": 90, "CritPct": 14, "CritDmg": 160, "Armure": 380, "Vitesse": 2.6, "Precision": 92, "Esquive": 16 }
+            "stats": { "PV": 1900, "AttMin": 75, "AttMax": 90, "CritPct": 14, "CritDmg": 160, "Armure": 380, "Vitesse": 2.6, "Precision": 92, "Esquive": 16 },
+            "abilities": [{
+                "id": "mind_flay", "name": "Fouet mental", "cooldown": 10, "chance": 0.5,
+                "effects": [{ "type": "debuff", "debuffType": "dot", "id": "mind_flay_dot", "name": "Fouet mental", "duration": 9, "damageType": "shadow", "totalDamage": { "source": "base_value", "multiplier": 120 } }]
+            }]
         },
         {
             "id": "icebound_warlord",
@@ -825,6 +902,7 @@
             "isBoss": true,
             "palier": 6,
             "stats": { "PV": 2125, "AttMin": 90, "AttMax": 109, "CritPct": 15, "CritDmg": 150, "Armure": 500, "Vitesse": 3.2, "Precision": 95, "Esquive": 10 },
+            "abilities": [{"id": "shattering_strike", "name": "Frappe fracassante", "cooldown": 12, "chance": 0.4, "effects": [{ "type": "damage", "damageType": "physical", "multiplier": 1.4 }, { "type": "debuff", "debuffType": "stat_modifier", "id": "shattering_armor_down", "name": "Armure fracassée", "duration": 10, "statMods": [{ "stat": "Armure", "modifier": "multiplicative", "value": 0.80 }] }] }],
             "specificLootTable": ["rep_silver_vanguard_helm", "rep_silver_vanguard_greataxe"]
         },
         {
@@ -835,6 +913,7 @@
             "isBoss": true,
             "palier": 7,
             "stats": { "PV": 2975, "AttMin": 114, "AttMax": 133, "CritPct": 10, "CritDmg": 150, "Armure": 700, "Vitesse": 3.4, "Precision": 100, "Esquive": 9 },
+            "abilities": [{"id": "scorching_smash", "name": "Fracas incandescent", "cooldown": 10, "chance": 0.5, "effects": [{ "type": "damage", "damageType": "fire", "multiplier": 1.6 }] }],
             "specificLootTable": ["rep_magma_callers_cowl", "rep_magma_callers_staff"]
         },
         {
@@ -845,6 +924,7 @@
             "isBoss": true,
             "palier": 8,
             "stats": { "PV": 3825, "AttMin": 142, "AttMax": 171, "CritPct": 18, "CritDmg": 160, "Armure": 800, "Vitesse": 2.6, "Precision": 105, "Esquive": 20 },
+            "abilities": [{"id": "natures_grasp", "name": "Poigne de la nature", "cooldown": 15, "chance": 0.4, "effects": [{ "type": "debuff", "debuffType": "stat_modifier", "id": "grasp_slow", "name": "Ralenti", "duration": 8, "statMods": [{ "stat": "Vitesse", "modifier": "multiplicative", "value": 1.40 }] }] }],
             "specificLootTable": ["rep_silent_path_mask", "rep_silent_path_daggers"]
         },
         {
@@ -855,6 +935,7 @@
             "isBoss": true,
             "palier": 9,
             "stats": { "PV": 4675, "AttMin": 180, "AttMax": 209, "CritPct": 22, "CritDmg": 180, "Armure": 900, "Vitesse": 2.0, "Precision": 110, "Esquive": 32 },
+            "abilities": [{"id": "soul_drain", "name": "Drain d'âme", "cooldown": 12, "chance": 0.5, "effects": [{ "type": "debuff", "debuffType": "dot", "id": "soul_drain_dot", "name": "Drain d'âme", "duration": 6, "damageType": "shadow", "totalDamage": { "source": "base_value", "multiplier": 150 } }] }],
             "specificLootTable": ["rep_faithsworn_diadem", "rep_faithsworn_mace"]
         },
         {
@@ -864,7 +945,8 @@
             "famille": "Humanoid",
             "isBoss": true,
             "palier": 10,
-            "stats": { "PV": 5740, "AttMin": 211, "AttMax": 248, "CritPct": 15, "CritDmg": 150, "Armure": 1500, "Vitesse": 3.2, "Precision": 115, "Esquive": 14 }
+            "stats": { "PV": 5740, "AttMin": 211, "AttMax": 248, "CritPct": 15, "CritDmg": 150, "Armure": 1500, "Vitesse": 3.2, "Precision": 115, "Esquive": 14 },
+            "abilities": [{"id": "crusader_strike", "name": "Frappe du croisé", "cooldown": 8, "chance": 0.6, "effects": [{ "type": "damage", "damageType": "holy", "multiplier": 1.3 }] }]
         },
         {
             "id": "ashwing_matriarch",
@@ -873,7 +955,8 @@
             "famille": "Beast",
             "isBoss": true,
             "palier": 11,
-            "stats": { "PV": 6560, "AttMin": 257, "AttMax": 294, "CritPct": 25, "CritDmg": 180, "Armure": 1600, "Vitesse": 2.2, "Precision": 120, "Esquive": 30 }
+            "stats": { "PV": 6560, "AttMin": 257, "AttMax": 294, "CritPct": 25, "CritDmg": 180, "Armure": 1600, "Vitesse": 2.2, "Precision": 120, "Esquive": 30 },
+            "abilities": [{"id": "wing_buffet", "name": "Coup d'aile", "cooldown": 18, "chance": 0.3, "effects": [{ "type": "debuff", "debuffType": "cc", "id": "wing_buffet_stun", "name": "Repoussé", "duration": 2.5, "ccType": "stun" }] }]
         },
         {
             "id": "colossus_of_the_grove",
@@ -882,7 +965,8 @@
             "famille": "Construct",
             "isBoss": true,
             "palier": 12,
-            "stats": { "PV": 9840, "AttMin": 322, "AttMax": 368, "CritPct": 10, "CritDmg": 150, "Armure": 2500, "Vitesse": 4.2, "Precision": 125, "Esquive": 7 }
+            "stats": { "PV": 9840, "AttMin": 322, "AttMax": 368, "CritPct": 10, "CritDmg": 150, "Armure": 2500, "Vitesse": 4.2, "Precision": 125, "Esquive": 7 },
+            "abilities": [{"id": "overgrowth", "name": "Surcroissance", "cooldown": 15, "chance": 0.4, "effects": [{ "type": "debuff", "debuffType": "stat_modifier", "id": "overgrowth_slow", "name": "Enraciné", "duration": 6, "statMods": [{ "stat": "Vitesse", "modifier": "multiplicative", "value": 1.5 }] }, { "type": "debuff", "debuffType": "dot", "id": "overgrowth_dot", "name": "Ronces", "duration": 6, "damageType": "nature", "totalDamage": { "source": "base_value", "multiplier": 180 } }] }]
         },
         {
             "id": "ancient_tomb_protector",
@@ -891,7 +975,8 @@
             "famille": "Construct",
             "isBoss": true,
             "palier": 13,
-            "stats": { "PV": 12000, "AttMin": 378, "AttMax": 432, "CritPct": 8, "CritDmg": 150, "Armure": 3500, "Vitesse": 4.5, "Precision": 130, "Esquive": 6 }
+            "stats": { "PV": 12000, "AttMin": 378, "AttMax": 432, "CritPct": 8, "CritDmg": 150, "Armure": 3500, "Vitesse": 4.5, "Precision": 130, "Esquive": 6 },
+            "abilities": [{"id": "stone_form", "name": "Forme de pierre", "cooldown": 25, "chance": 0.25, "effects": [{ "type": "buff", "buffType": "stat_modifier", "id": "stone_form_buff", "name": "Forme de pierre", "duration": 8, "statMods": [{ "stat": "Armure", "modifier": "multiplicative", "value": 3.0 }] }] }]
         },
         {
             "id": "garak_frostfang",
@@ -901,6 +986,7 @@
             "isBoss": true,
             "palier": 7,
             "stats": { "PV": 3500, "AttMin": 120, "AttMax": 150, "CritPct": 15, "CritDmg": 160, "Armure": 800, "Vitesse": 3.0, "Precision": 100, "Esquive": 12, "ResElems": { "ice": 50, "fire": -25 } },
+            "abilities": [{"id": "frost_breath", "name": "Souffle de Givre", "cooldown": 12, "chance": 0.5, "effects": [{ "type": "damage", "damageType": "ice", "multiplier": 1.5 }, { "type": "debuff", "debuffType": "stat_modifier", "id": "frost_breath_slow", "name": "Souffle glacial", "duration": 8, "statMods": [{ "stat": "Vitesse", "modifier": "multiplicative", "value": 1.35 }] }] }],
             "specificLootTable": ["garaks_icy_maw", "frostfang_bite"]
         },
         {
@@ -928,7 +1014,11 @@
             "level": 53,
             "isBoss": true,
             "palier": 11,
-            "stats": { "PV": 1500, "AttMin": 60, "AttMax": 90, "CritPct": 15, "CritDmg": 175, "Armure": 250, "Vitesse": 2.5, "Precision": 115, "Esquive": 15 }
+            "stats": { "PV": 1500, "AttMin": 60, "AttMax": 90, "CritPct": 15, "CritDmg": 175, "Armure": 250, "Vitesse": 2.5, "Precision": 115, "Esquive": 15 },
+            "abilities": [{
+                "id": "get_back_to_work", "name": "Au travail !", "cooldown": 15, "chance": 0.4,
+                "effects": [{ "type": "debuff", "debuffType": "cc", "id": "supervisor_stun", "name": "Intimidation", "duration": 2, "ccType": "stun" }]
+            }]
         },
         {
             "id": "kobold_miner_assistant_heroic",
@@ -956,7 +1046,14 @@
             "famille": "Beast",
             "isBoss": true,
             "palier": 11,
-            "stats": { "PV": 2000, "AttMin": 75, "AttMax": 110, "CritPct": 17, "CritDmg": 175, "Armure": 200, "Vitesse": 2.0, "Precision": 120, "Esquive": 30 }
+            "stats": { "PV": 2000, "AttMin": 75, "AttMax": 110, "CritPct": 17, "CritDmg": 175, "Armure": 200, "Vitesse": 2.0, "Precision": 120, "Esquive": 30 },
+            "abilities": [{
+                "id": "sonic_screech_heroic", "name": "Cri Sonique", "cooldown": 12, "chance": 0.5,
+                "effects": [
+                    { "type": "debuff", "debuffType": "stat_modifier", "id": "screech_armor_down_heroic", "name": "Armure brisée (H)", "duration": 10, "statMods": [{ "stat": "Armure", "modifier": "multiplicative", "value": 0.75 }] },
+                    { "type": "debuff", "debuffType": "stat_modifier", "id": "screech_precision_down_heroic", "name": "Désorienté (H)", "duration": 10, "statMods": [{ "stat": "Precision", "modifier": "multiplicative", "value": 0.80 }] }
+                ]
+            }]
         },
         {
             "id": "yeti_chieftain_heroic",
@@ -965,7 +1062,14 @@
             "famille": "Giant",
             "isBoss": true,
             "palier": 12,
-            "stats": { "PV": 6000, "AttMin": 125, "AttMax": 175, "CritPct": 13, "CritDmg": 175, "Armure": 750, "Vitesse": 3.2, "Precision": 125, "Esquive": 20 }
+            "stats": { "PV": 6000, "AttMin": 125, "AttMax": 175, "CritPct": 13, "CritDmg": 175, "Armure": 750, "Vitesse": 3.2, "Precision": 125, "Esquive": 20 },
+            "abilities": [{
+                "id": "seismic_slam_heroic", "name": "Frappe Sismique", "cooldown": 15, "chance": 0.4,
+                "effects": [
+                    { "type": "damage", "damageType": "physical", "multiplier": 1.8 },
+                    { "type": "debuff", "debuffType": "cc", "id": "slam_stun_heroic", "name": "Assommé (H)", "duration": 3, "ccType": "stun" }
+                ]
+            }]
         },
         {
             "id": "inferno_elemental_lord_heroic",
@@ -974,7 +1078,14 @@
             "famille": "Elemental",
             "isBoss": true,
             "palier": 13,
-            "stats": { "PV": 8000, "AttMin": 225, "AttMax": 275, "CritPct": 15, "CritDmg": 175, "Armure": 900, "Vitesse": 2.7, "Precision": 130, "Esquive": 22 }
+            "stats": { "PV": 8000, "AttMin": 225, "AttMax": 275, "CritPct": 15, "CritDmg": 175, "Armure": 900, "Vitesse": 2.7, "Precision": 130, "Esquive": 22 },
+            "abilities": [{
+                "id": "firestorm_heroic", "name": "Tempête de Feu", "cooldown": 15, "chance": 0.5,
+                "effects": [
+                    { "type": "damage", "damageType": "fire", "multiplier": 1.2 },
+                    { "type": "debuff", "debuffType": "dot", "id": "immolation_dot_heroic", "name": "Immolation (H)", "duration": 9, "damageType": "fire", "totalDamage": { "source": "base_value", "multiplier": 200 } }
+                ]
+            }]
         },
         {
             "id": "ancient_dryad_matriarch_heroic",
@@ -983,7 +1094,14 @@
             "famille": "Fey",
             "isBoss": true,
             "palier": 14,
-            "stats": { "PV": 12000, "AttMin": 300, "AttMax": 375, "CritPct": 20, "CritDmg": 185, "Armure": 1250, "Vitesse": 2.4, "Precision": 135, "Esquive": 28 }
+            "stats": { "PV": 12000, "AttMin": 300, "AttMax": 375, "CritPct": 20, "CritDmg": 185, "Armure": 1250, "Vitesse": 2.4, "Precision": 135, "Esquive": 28 },
+            "abilities": [{
+                "id": "thornbark_heroic", "name": "Écorce d'Épines", "cooldown": 20, "chance": 0.4,
+                "effects": [
+                    { "type": "buff", "buffType": "stat_modifier", "id": "barkskin_buff_heroic", "name": "Écorcefer (H)", "duration": 12, "statMods": [{ "stat": "Armure", "modifier": "multiplicative", "value": 2.50 }] },
+                    { "type": "buff", "buffType": "damage_reflection", "id": "thorns_buff_heroic", "name": "Épines (H)", "duration": 12, "reflectionValue": 0.30 }
+                ]
+            }]
         },
         {
             "id": "void_cultist_leader_heroic",
@@ -992,7 +1110,14 @@
             "famille": "Humanoid",
             "isBoss": true,
             "palier": 15,
-            "stats": { "PV": 18000, "AttMin": 350, "AttMax": 425, "CritPct": 17, "CritDmg": 175, "Armure": 1750, "Vitesse": 2.8, "Precision": 140, "Esquive": 24 }
+            "stats": { "PV": 18000, "AttMin": 350, "AttMax": 425, "CritPct": 17, "CritDmg": 175, "Armure": 1750, "Vitesse": 2.8, "Precision": 140, "Esquive": 24 },
+            "abilities": [{
+                "id": "voids_embrace_heroic", "name": "Étreinte du Vide", "cooldown": 12, "chance": 0.6,
+                "effects": [
+                    { "type": "debuff", "debuffType": "vulnerability", "id": "shadow_vuln_heroic", "name": "Vulnérabilité à l'Ombre (H)", "duration": 8, "damageType": "shadow", "multiplier": 1.25 },
+                    { "type": "damage", "damageType": "shadow", "multiplier": 1.3 }
+                ]
+            }]
         },
         {
             "id": "void_priest_heroic",
@@ -1001,7 +1126,17 @@
             "famille": "Humanoid",
             "isBoss": true,
             "palier": 15,
-            "stats": { "PV": 19000, "AttMin": 375, "AttMax": 450, "CritPct": 19, "CritDmg": 185, "Armure": 1900, "Vitesse": 2.6, "Precision": 142, "Esquive": 26 }
+            "stats": { "PV": 19000, "AttMin": 375, "AttMax": 450, "CritPct": 19, "CritDmg": 185, "Armure": 1900, "Vitesse": 2.6, "Precision": 142, "Esquive": 26 },
+            "abilities": [{
+                "id": "eternal_torment_heroic", "name": "Tourment Éternel", "cooldown": 15, "chance": 0.5,
+                "effects": [
+                    { "type": "debuff", "debuffType": "dot", "id": "mind_flay_dot_heroic", "name": "Fouet mental (H)", "duration": 9, "damageType": "shadow", "totalDamage": { "source": "base_value", "multiplier": 250 } },
+                    { "type": "debuff", "debuffType": "stat_modifier", "id": "power_drain_heroic", "name": "Puissance drainée (H)", "duration": 9, "statMods": [
+                        { "stat": "AttMin", "modifier": "multiplicative", "value": 0.85 },
+                        { "stat": "AttMax", "modifier": "multiplicative", "value": 0.85 }
+                    ]}
+                ]
+            }]
         },
         {
             "id": "icebound_warlord_heroic",
@@ -1010,7 +1145,15 @@
             "famille": "Humanoid",
             "isBoss": true,
             "palier": 16,
-            "stats": { "PV": 25000, "AttMin": 475, "AttMax": 575, "CritPct": 20, "CritDmg": 175, "Armure": 2500, "Vitesse": 3.2, "Precision": 145, "Esquive": 20 }
+            "stats": { "PV": 25000, "AttMin": 475, "AttMax": 575, "CritPct": 20, "CritDmg": 175, "Armure": 2500, "Vitesse": 3.2, "Precision": 145, "Esquive": 20 },
+            "abilities": [{
+                "id": "glacial_annihilation_heroic", "name": "Anéantissement Glacial", "cooldown": 12, "chance": 0.5,
+                "effects": [
+                    { "type": "damage", "damageType": "physical", "multiplier": 0.75 },
+                    { "type": "damage", "damageType": "ice", "multiplier": 0.75 },
+                    { "type": "debuff", "debuffType": "stat_modifier", "id": "shattering_armor_down_heroic", "name": "Armure fracassée (H)", "duration": 12, "statMods": [{ "stat": "Armure", "modifier": "multiplicative", "value": 0.65 }] }
+                ]
+            }]
         },
         {
             "id": "fire_giant_champion_heroic",
@@ -1019,7 +1162,14 @@
             "famille": "Giant",
             "isBoss": true,
             "palier": 17,
-            "stats": { "PV": 35000, "AttMin": 600, "AttMax": 700, "CritPct": 15, "CritDmg": 175, "Armure": 3500, "Vitesse": 3.4, "Precision": 150, "Esquive": 19 }
+            "stats": { "PV": 35000, "AttMin": 600, "AttMax": 700, "CritPct": 15, "CritDmg": 175, "Armure": 3500, "Vitesse": 3.4, "Precision": 150, "Esquive": 19 },
+            "abilities": [{
+                "id": "ashen_mark_heroic", "name": "Marque Cendrée", "cooldown": 16, "chance": 0.4,
+                "effects": [
+                    { "type": "damage", "damageType": "fire", "multiplier": 1.8 },
+                    { "type": "debuff", "debuffType": "healing_received_modifier", "id": "mortal_wound_heroic", "name": "Marque Cendrée (H)", "duration": 10, "multiplier": 0.50 }
+                ]
+            }]
         },
         {
             "id": "guardian_of_the_grove_heroic",
@@ -1028,7 +1178,8 @@
             "famille": "Fey",
             "isBoss": true,
             "palier": 18,
-            "stats": { "PV": 45000, "AttMin": 750, "AttMax": 900, "CritPct": 23, "CritDmg": 185, "Armure": 4000, "Vitesse": 2.6, "Precision": 155, "Esquive": 30 }
+            "stats": { "PV": 45000, "AttMin": 750, "AttMax": 900, "CritPct": 23, "CritDmg": 185, "Armure": 4000, "Vitesse": 2.6, "Precision": 155, "Esquive": 30 },
+            "abilities": [{"id": "primordial_grasp_heroic", "name": "Emprise Primordiale", "cooldown": 18, "chance": 0.4, "effects": [{ "type": "debuff", "debuffType": "cc", "id": "grasp_root_heroic", "name": "Enraciné (H)", "duration": 4, "ccType": "stun" }, { "type": "debuff", "debuffType": "dot", "id": "grasp_dot_heroic", "name": "Ronces (H)", "duration": 4, "damageType": "nature", "totalDamage": { "source": "base_value", "multiplier": 300 } }] }]
         },
         {
             "id": "spectral_overlord_heroic",
@@ -1037,7 +1188,8 @@
             "famille": "Undead",
             "isBoss": true,
             "palier": 19,
-            "stats": { "PV": 55000, "AttMin": 950, "AttMax": 1100, "CritPct": 27, "CritDmg": 205, "Armure": 4500, "Vitesse": 2.0, "Precision": 160, "Esquive": 42 }
+            "stats": { "PV": 55000, "AttMin": 950, "AttMax": 1100, "CritPct": 27, "CritDmg": 205, "Armure": 4500, "Vitesse": 2.0, "Precision": 160, "Esquive": 42 },
+            "abilities": [{"id": "feast_of_souls_heroic", "name": "Festin d'Âmes", "cooldown": 20, "chance": 0.5, "effects": [{ "type": "debuff", "debuffType": "dot", "id": "soul_drain_dot_heroic", "name": "Drain d'âme (H)", "duration": 8, "damageType": "shadow", "totalDamage": { "source": "base_value", "multiplier": 400 } }, { "type": "buff", "buffType": "hot", "id": "soul_feast_hot_heroic", "name": "Festin (H)", "duration": 8, "totalHeal": { "source": "max_health_percentage", "percentage": 0.05 } }] }]
         },
         {
             "id": "boreal_crusader_heroic",
@@ -1046,7 +1198,8 @@
             "famille": "Humanoid",
             "isBoss": true,
             "palier": 20,
-            "stats": { "PV": 70000, "AttMin": 1150, "AttMax": 1350, "CritPct": 20, "CritDmg": 175, "Armure": 7500, "Vitesse": 3.2, "Precision": 165, "Esquive": 24 }
+            "stats": { "PV": 70000, "AttMin": 1150, "AttMax": 1350, "CritPct": 20, "CritDmg": 175, "Armure": 7500, "Vitesse": 3.2, "Precision": 165, "Esquive": 24 },
+            "abilities": [{"id": "holy_judgment_heroic", "name": "Jugement Sacré", "cooldown": 15, "chance": 0.5, "effects": [{ "type": "damage", "damageType": "holy", "multiplier": 1.6 }, { "type": "buff", "buffType": "stat_modifier", "id": "judgment_buff_heroic", "name": "Jugement (H)", "duration": 10, "statMods": [{ "stat": "Vitesse", "modifier": "multiplicative_add", "value": -0.20 }, { "stat": "Precision", "modifier": "multiplicative", "value": 1.20 }] }] }]
         },
         {
             "id": "ashwing_matriarch_heroic",
@@ -1055,7 +1208,8 @@
             "famille": "Beast",
             "isBoss": true,
             "palier": 21,
-            "stats": { "PV": 80000, "AttMin": 1400, "AttMax": 1600, "CritPct": 30, "CritDmg": 205, "Armure": 8000, "Vitesse": 2.2, "Precision": 170, "Esquive": 40 }
+            "stats": { "PV": 80000, "AttMin": 1400, "AttMax": 1600, "CritPct": 30, "CritDmg": 205, "Armure": 8000, "Vitesse": 2.2, "Precision": 170, "Esquive": 40 },
+            "abilities": [{"id": "ashen_tempest_heroic", "name": "Tempête de Cendres", "cooldown": 18, "chance": 0.4, "effects": [{ "type": "damage", "damageType": "physical", "multiplier": 1.5 }, { "type": "debuff", "debuffType": "stat_modifier", "id": "tempest_debuff_heroic", "name": "Aveuglé (H)", "duration": 8, "statMods": [{ "stat": "Precision", "modifier": "multiplicative", "value": 0.70 }, { "stat": "CritPct", "modifier": "multiplicative", "value": 0.70 }] }] }]
         },
         {
             "id": "colossus_of_the_grove_heroic",
@@ -1064,7 +1218,8 @@
             "famille": "Construct",
             "isBoss": true,
             "palier": 22,
-            "stats": { "PV": 120000, "AttMin": 1750, "AttMax": 2000, "CritPct": 15, "CritDmg": 175, "Armure": 12500, "Vitesse": 4.2, "Precision": 175, "Esquive": 17 }
+            "stats": { "PV": 120000, "AttMin": 1750, "AttMax": 2000, "CritPct": 15, "CritDmg": 175, "Armure": 12500, "Vitesse": 4.2, "Precision": 175, "Esquive": 17 },
+            "abilities": [{"id": "colossal_slam_heroic", "name": "Frappe Colossale", "cooldown": 20, "chance": 0.4, "effects": [{ "type": "damage", "damageType": "physical", "multiplier": 2.0 }, { "type": "debuff", "debuffType": "stat_modifier", "id": "colossal_slow_heroic", "name": "Écrasé (H)", "duration": 10, "statMods": [{ "stat": "Vitesse", "modifier": "multiplicative", "value": 1.50 }] }] }]
         },
         {
             "id": "ancient_tomb_protector_heroic",
@@ -1073,7 +1228,8 @@
             "famille": "Construct",
             "isBoss": true,
             "palier": 23,
-            "stats": { "PV": 150000, "AttMin": 2100, "AttMax": 2400, "CritPct": 13, "CritDmg": 175, "Armure": 17500, "Vitesse": 4.5, "Precision": 180, "Esquive": 16 }
+            "stats": { "PV": 150000, "AttMin": 2100, "AttMax": 2400, "CritPct": 13, "CritDmg": 175, "Armure": 17500, "Vitesse": 4.5, "Precision": 180, "Esquive": 16 },
+            "abilities": [{"id": "immutable_form_heroic", "name": "Forme Immuable", "cooldown": 30, "chance": 0.3, "effects": [{ "type": "buff", "buffType": "stat_modifier", "id": "stone_form_buff_heroic", "name": "Forme de pierre (H)", "duration": 10, "statMods": [{ "stat": "Armure", "modifier": "multiplicative", "value": 4.0 }] }, { "type": "buff", "buffType": "hot", "id": "stone_regen_heroic", "name": "Régénération (H)", "duration": 10, "totalHeal": { "source": "max_health_percentage", "percentage": 0.15 } }] }]
         }
     ]
 }

--- a/public/data/skills.json
+++ b/public/data/skills.json
@@ -181,6 +181,22 @@
                 "Frappe la cible 3 fois pour 50% des dégâts de l'arme à chaque fois.",
                 "Coûte 20 Rage."
             ],
+            "effects": [
+                {
+                    "type": "multi_strike",
+                    "strikes": 3,
+                    "damage": {
+                        "type": "damage",
+                        "damageType": "physical",
+                        "source": "weapon",
+                        "multiplier": 0.5
+                    }
+                },
+                {
+                    "type": "resource_cost",
+                    "amount": 20
+                }
+            ],
             "cooldown": 8
         },
         {
@@ -233,6 +249,22 @@
                 "Déchaîne une fureur d'attaques, frappant la cible principale 5 fois pour 60% des dégâts de l'arme.",
                 "Coûte 40 Rage."
             ],
+            "effects": [
+                {
+                    "type": "multi_strike",
+                    "strikes": 5,
+                    "damage": {
+                        "type": "damage",
+                        "damageType": "physical",
+                        "source": "weapon",
+                        "multiplier": 0.6
+                    }
+                },
+                {
+                    "type": "resource_cost",
+                    "amount": 40
+                }
+            ],
             "cooldown": 15
         },
         {
@@ -271,9 +303,18 @@
             "exigences": [
                 "berserker_titan_shield_wall:1"
             ],
-            "effets": [
-                "Augmente temporairement vos PV maximum de 30% pendant 20 secondes.",
-                "Ne coûte rien."
+            "effets": [],
+            "effects": [
+                {
+                    "type": "buff",
+                    "id": "last_stand_buff",
+                    "name": "Dernier Rempart",
+                    "duration": 20,
+                    "buffType": "stat_modifier",
+                    "statMods": [
+                        { "stat": "PV", "modifier": "multiplicative_add", "value": 0.30 }
+                    ]
+                }
             ],
             "cooldown": 180
         },
@@ -343,6 +384,22 @@
             "effets": [
                 "Tire 3/3/4/4/5 vagues de missiles infligeant 5 dégâts des Arcanes chacune.",
                 "Coûte 12 Mana."
+            ],
+            "effects": [
+                {
+                    "type": "multi_strike",
+                    "strikes": [3, 3, 4, 4, 5],
+                    "damage": {
+                        "type": "damage",
+                        "damageType": "arcane",
+                        "source": "spell",
+                        "baseValue": 5
+                    }
+                },
+                {
+                    "type": "resource_cost",
+                    "amount": 12
+                }
             ]
         },
         {
@@ -383,6 +440,30 @@
             "effets": [
                 "Inflige 10 dégâts de Feu et augmente les chances de coup critique contre la cible de 5% pendant 30s. Cumulable 5 fois.",
                 "Coûte 5 Mana."
+            ],
+            "effects": [
+                {
+                    "type": "damage",
+                    "damageType": "fire",
+                    "source": "spell",
+                    "baseValue": 10
+                },
+                {
+                    "type": "debuff",
+                    "debuffType": "stat_modifier",
+                    "id": "scorch_crit_debuff",
+                    "name": "Brûlure (Crit)",
+                    "duration": 30,
+                    "is_stacking": true,
+                    "max_stacks": 5,
+                    "statMods": [
+                        { "stat": "CritChanceTakenModifier", "modifier": "additive", "value": 5 }
+                    ]
+                },
+                {
+                    "type": "resource_cost",
+                    "amount": 5
+                }
             ]
         },
         {
@@ -399,6 +480,13 @@
                 "Augmente votre hâte et vos chances de coup critique de 100% pendant 10s.",
                 "Coûte 50 Mana."
             ],
+            "effects": [
+                { "type": "buff", "id": "combustion_buff", "name": "Combustion", "duration": 10000, "buffType": "stat_modifier", "statMods": [
+                    { "stat": "CritPct", "modifier": "additive", "value": 100 },
+                    { "stat": "Vitesse", "modifier": "multiplicative", "value": 0.5 }
+                ]},
+                { "type": "resource_cost", "amount": 50 }
+            ],
             "cooldown": 120
         },
         {
@@ -411,6 +499,10 @@
             "effets": [
                 "Inflige 100 dégâts de Feu. Temps d'incantation de 3.5s.",
                 "Coûte 40 Mana."
+            ],
+            "effects": [
+                { "type": "damage", "damageType": "fire", "source": "spell", "baseValue": 100 },
+                { "type": "resource_cost", "amount": 40 }
             ]
         },
         {
@@ -480,6 +572,27 @@
             "effets": [
                 "Inflige 20 dégâts des Arcanes. Chaque utilisation augmente son coût en mana de 100% et ses dégâts de 50%. Cumulable 4 fois.",
                 "Coûte 10 Mana."
+            ],
+            "effects": [
+                {
+                    "type": "stacking_damage_and_cost",
+                    "damage": {
+                        "damageType": "arcane",
+                        "source": "spell",
+                        "baseValue": 20,
+                        "stack_multiplier": 0.5
+                    },
+                    "cost": {
+                        "base_amount": 10,
+                        "stack_multiplier": 1.0
+                    },
+                    "stacking_buff": {
+                        "id": "arcane_charge",
+                        "name": "Charge arcanique",
+                        "max_stacks": 4,
+                        "duration": 10000
+                    }
+                }
             ]
         },
         {
@@ -541,6 +654,19 @@
             "effets": [
                 "Une attaque rapide qui inflige 100% des dégâts de l'arme + 5/10/15/20/25.",
                 "Coûte 30 Énergie."
+            ],
+            "effects": [
+                {
+                    "type": "damage",
+                    "damageType": "physical",
+                    "source": "weapon",
+                    "multiplier": 1.0,
+                    "bonus_flat_damage": [5, 10, 15, 20, 25]
+                },
+                {
+                    "type": "resource_cost",
+                    "amount": 30
+                }
             ]
         },
         {
@@ -697,6 +823,18 @@
             "effets": [
                 "Consomme les charges de Poison mortel sur la cible pour infliger 20 dégâts de Nature par charge.",
                 "Coûte 35 Énergie."
+            ],
+            "effects": [
+                {
+                    "type": "consume_debuff_for_damage",
+                    "debuff_id_to_consume": "deadly_poison_debuff",
+                    "damage_per_stack": 20,
+                    "damageType": "nature"
+                },
+                {
+                    "type": "resource_cost",
+                    "amount": 35
+                }
             ]
         },
         {
@@ -771,6 +909,17 @@
             "effets": [
                 "Un sort rapide qui vous rend 20/28/36/45/55 PV.",
                 "Coûte 15 Mana."
+            ],
+            "effects": [
+                {
+                    "type": "heal",
+                    "source": "spell",
+                    "baseValue": [20, 28, 36, 45, 55]
+                },
+                {
+                    "type": "resource_cost",
+                    "amount": 15
+                }
             ]
         },
         {
@@ -784,6 +933,18 @@
             "effets": [
                 "Inflige 18/25/32/40/48 dégâts du Sacré à un ennemi.",
                 "Coûte 12 Mana."
+            ],
+            "effects": [
+                {
+                    "type": "damage",
+                    "damageType": "holy",
+                    "source": "spell",
+                    "baseValue": [18, 25, 32, 40, 48]
+                },
+                {
+                    "type": "resource_cost",
+                    "amount": 12
+                }
             ]
         },
         {
@@ -848,6 +1009,23 @@
                 "Vous entoure d'une lumière sacrée, vous soignant pour 120 PV en 12 secondes.",
                 "Coûte 40 Mana."
             ],
+            "effects": [
+                {
+                    "type": "buff",
+                    "id": "prayer_of_healing_hot",
+                    "name": "Prière de guérison",
+                    "duration": 12000,
+                    "buffType": "hot",
+                    "totalHealing": {
+                        "source": "base_value",
+                        "multiplier": 120
+                    }
+                },
+                {
+                    "type": "resource_cost",
+                    "amount": 40
+                }
+            ],
             "cooldown": 10
         },
         {
@@ -883,6 +1061,25 @@
             "effets": [
                 "Lance une volée de lumière sacrée sur la cible, infligeant 15 dégâts 3 fois en 2s.",
                 "Coûte 25 Mana."
+            ],
+            "effects": [
+                {
+                    "type": "debuff",
+                    "debuffType": "dot",
+                    "id": "penance_dot",
+                    "name": "Pénitence",
+                    "duration": 2,
+                    "damageType": "holy",
+                    "num_ticks": 3,
+                    "totalDamage": {
+                        "source": "spell",
+                        "baseValue": 45
+                    }
+                },
+                {
+                    "type": "resource_cost",
+                    "amount": 25
+                }
             ],
             "cooldown": 9
         },
@@ -927,6 +1124,26 @@
             "cooldown": 15
         },
         {
+            "id": "mage_arcane_archon_skill",
+            "nom": "Archonte",
+            "classeId": "mage",
+            "type": "actif",
+            "rangMax": 1,
+            "niveauRequis": 150,
+            "effets": ["Vous transforme en Archonte pendant 20s, doublant les dégâts de vos sorts et annulant leur coût en mana."],
+            "cooldown": 180,
+            "effects": [
+                {
+                    "type": "buff",
+                    "id": "archon_buff",
+                    "name": "Forme d'Archonte",
+                    "duration": 20000,
+                    "buffType": "special"
+                },
+                { "type": "resource_cost", "amount": 0 }
+            ]
+        },
+        {
             "id": "cleric_shadow_shadowform",
             "nom": "Forme d'ombre",
             "classeId": "cleric",
@@ -947,6 +1164,30 @@
                 },
                 { "type": "resource_cost", "amount": 10 }
             ]
+        },
+        {
+            "id": "cleric_discipline_dome_de_lumiere",
+            "nom": "Dôme de Lumière",
+            "classeId": "cleric",
+            "type": "actif",
+            "school": "holy",
+            "rangMax": 1,
+            "niveauRequis": 100,
+            "cooldown": 300,
+            "effets": [],
+            "effects": [
+                {
+                    "type": "buff",
+                    "id": "dome_of_light",
+                    "name": "Dôme de Lumière",
+                    "duration": 10,
+                    "buffType": "stat_modifier",
+                    "statMods": [
+                        { "stat": "DamageReductionMultiplier", "modifier": "multiplicative", "value": 0.50 }
+                    ]
+                }
+            ],
+            "exigences": ["cleric_discipline_suppression_de_la_douleur:1"]
         }
     ]
 }

--- a/public/data/talents.json
+++ b/public/data/talents.json
@@ -8,7 +8,16 @@
       "type": "passif",
       "niveauRequis": 1,
       "rangMax": 5,
-      "effets": ["Augmente les dégâts de base de 2/4/6/8/10%."],
+      "effets": [
+        {
+          "type": "buff",
+          "buffType": "stat_modifier",
+          "statMods": [
+            { "stat": "AttMin", "modifier": "multiplicative", "value": [1.02, 1.04, 1.06, 1.08, 1.10] },
+            { "stat": "AttMax", "modifier": "multiplicative", "value": [1.02, 1.04, 1.06, 1.08, 1.10] }
+          ]
+        }
+      ],
       "exigences": []
     },
     {
@@ -18,7 +27,15 @@
       "type": "passif",
       "niveauRequis": 1,
       "rangMax": 5,
-      "effets": ["Augmente les chances de coup critique de 1/2/3/4/5%."],
+      "effets": [
+        {
+          "type": "buff",
+          "buffType": "stat_modifier",
+          "statMods": [
+            { "stat": "CritPct", "modifier": "additive", "value": [1, 2, 3, 4, 5] }
+          ]
+        }
+      ],
       "exigences": []
     },
     {
@@ -28,7 +45,15 @@
       "type": "passif",
       "niveauRequis": 10,
       "rangMax": 3,
-      "effets": ["Augmente les dégâts des coups critiques de 10/20/30%."],
+      "effets": [
+        {
+          "type": "buff",
+          "buffType": "stat_modifier",
+          "statMods": [
+            { "stat": "CritDmg", "modifier": "additive", "value": [10, 20, 30] }
+          ]
+        }
+      ],
       "exigences": ["berserker_armes_precision_mortelle:1"]
     },
     {
@@ -39,6 +64,26 @@
       "niveauRequis": 20,
       "rangMax": 5,
       "effets": ["Vos coups critiques ont 5/10/15/20/25% de chance de réduire l'armure de la cible de 10% pendant 5s."],
+      "triggeredEffects": [
+        {
+          "trigger": "on_critical_hit",
+          "chance": [0.05, 0.1, 0.15, 0.2, 0.25],
+          "effects": [
+            {
+              "type": "apply_debuff",
+              "debuff": {
+                "id": "dechainement_critique_armor_reduction",
+                "name": "Armure Réduite",
+                "duration": 5,
+                "debuffType": "stat_modifier",
+                "statMods": [
+                  { "stat": "Armure", "modifier": "multiplicative", "value": 0.9 }
+                ]
+              }
+            }
+          ]
+        }
+      ],
       "exigences": ["berserker_armes_frappes_devastatrices:1"]
     },
     {
@@ -80,7 +125,7 @@
       "type": "passif",
       "niveauRequis": 20,
       "rangMax": 5,
-      "effets": ["Vos attaques ont une chance de 20% d'ignorer 10/20/30/40/50% de l'armure de la cible."],
+      "description": ["Vos attaques ont une chance de 20% d'ignorer 10/20/30/40/50% de l'armure de la cible."],
        "effects": [
         {
             "type": "on_hit_effect",
@@ -98,7 +143,13 @@
       "type": "passif",
       "niveauRequis": 50,
       "rangMax": 1,
-      "effets": ["Augmente les dégâts des armes à deux mains de 15% mais réduit la vitesse d'attaque de 10%."],
+      "effets": [{
+        "type": "buff", "buffType": "stat_modifier",
+        "statMods": [
+            { "stat": "DamageMultiplier", "modifier": "additive", "value": 0.15, "condition": { "requires_weapon_type": "two_handed" } },
+            { "stat": "Vitesse", "modifier": "multiplicative", "value": 1.10, "condition": { "requires_weapon_type": "two_handed" } }
+        ]
+      }],
       "exigences": ["berserker_armes_fracas_armure:3", "berserker_armes_dechainement_critique:3"]
     },
      {
@@ -108,7 +159,10 @@
       "type": "passif",
       "niveauRequis": 100,
       "rangMax": 1,
-      "effets": ["Les attaques contre les cibles ayant moins de 20% de PV infligent 50% de dégâts supplémentaires."],
+      "effets": [{
+          "type": "buff", "buffType": "stat_modifier",
+          "statMods": [{ "stat": "DamageMultiplier", "modifier": "additive", "value": 0.5, "condition": { "target_hp_less_than": 20 } }]
+      }],
       "exigences": ["berserker_armes_maitrise_deux_mains:1"]
     },
     {
@@ -118,7 +172,15 @@
       "type": "passif",
       "niveauRequis": 1,
       "rangMax": 5,
-      "effets": ["Augmente la vitesse d'attaque de 1/2/3/4/5%."],
+      "effets": [
+        {
+          "type": "buff",
+          "buffType": "stat_modifier",
+          "statMods": [
+            { "stat": "Vitesse", "modifier": "multiplicative", "value": [0.99, 0.98, 0.97, 0.96, 0.95] }
+          ]
+        }
+      ],
       "exigences": []
     },
     {
@@ -128,7 +190,29 @@
       "type": "passif",
       "niveauRequis": 10,
       "rangMax": 3,
-      "effets": ["Chaque attaque portée augmente votre vitesse d'attaque de 1% pendant 5s. Cumulable 5/10/15 fois."],
+      "effets": [],
+      "triggeredEffects": [
+        {
+          "trigger": "on_hit",
+          "chance": 1.0,
+          "effects": [
+            {
+              "type": "apply_buff",
+              "buff": {
+                "id": "enrage_speed_buff",
+                "name": "Enragé",
+                "duration": 5000,
+                "is_stacking": true,
+                "max_stacks": [5, 10, 15],
+                "buffType": "stat_modifier",
+                "statMods": [
+                  { "stat": "Vitesse", "modifier": "multiplicative", "value": 0.99 }
+                ]
+              }
+            }
+          ]
+        }
+      ],
       "exigences": ["berserker_fureur_celerite:1"]
     },
     {
@@ -138,7 +222,15 @@
       "type": "passif",
       "niveauRequis": 20,
       "rangMax": 5,
-      "effets": ["Augmente les chances de coup critique de 1/2/3/4/5%."],
+      "effets": [
+        {
+          "type": "buff",
+          "buffType": "stat_modifier",
+          "statMods": [
+            { "stat": "CritPct", "modifier": "additive", "value": [1, 2, 3, 4, 5] }
+          ]
+        }
+      ],
       "exigences": ["berserker_fureur_enrage:1"]
     },
     {
@@ -168,7 +260,15 @@
       "type": "passif",
       "niveauRequis": 1,
       "rangMax": 5,
-      "effets": ["Augmente l'armure de 5/10/15/20/25%."],
+      "effets": [
+        {
+          "type": "buff",
+          "buffType": "stat_modifier",
+          "statMods": [
+            { "stat": "Armure", "modifier": "multiplicative", "value": [1.05, 1.10, 1.15, 1.20, 1.25] }
+          ]
+        }
+      ],
       "exigences": []
     },
     {
@@ -178,7 +278,7 @@
       "type": "passif",
       "niveauRequis": 10,
       "rangMax": 3,
-      "effets": ["Vous régénérez 0.5/1/1.5% de votre vie maximale chaque seconde en combat."],
+      "description": ["Vous régénérez 0.5/1/1.5% de votre vie maximale chaque seconde en combat."],
       "effects": [
           {
               "type": "buff",
@@ -200,7 +300,15 @@
       "type": "passif",
       "niveauRequis": 20,
       "rangMax": 5,
-      "effets": ["Réduit les dégâts subis de 2/4/6/8/10%."],
+      "effets": [
+        {
+          "type": "buff",
+          "buffType": "stat_modifier",
+          "statMods": [
+            { "stat": "DamageReductionMultiplier", "modifier": "additive", "value": [-0.02, -0.04, -0.06, -0.08, -0.10] }
+          ]
+        }
+      ],
       "exigences": ["berserker_titan_second_souffle:1"]
     },
     {
@@ -220,7 +328,14 @@
       "type": "passif",
       "niveauRequis": 100,
       "rangMax": 1,
-      "effets": ["Les dégâts qui devraient vous tuer vous laissent à 1 PV à la place. Ne peut se produire qu'une fois par combat."],
+      "effets": [],
+      "effects": [
+        {
+          "type": "cheat_death",
+          "heal_percent": 0,
+          "set_hp_to_1": true
+        }
+      ],
       "exigences": ["berserker_titan_mur_de_fer:1"]
     },
     {
@@ -231,6 +346,19 @@
       "niveauRequis": 1,
       "rangMax": 5,
       "effets": ["Augmente les dégâts de Boule de Feu de 5/10/15/20/25%."],
+      "skill_mods": [
+        {
+          "skill_id": "mage_fire_fireball",
+          "modifications": [
+            {
+              "effect_index": 0,
+              "property_path": "baseValue",
+              "modifier": "multiplicative",
+              "value": [1.05, 1.1, 1.15, 1.2, 1.25]
+            }
+          ]
+        }
+      ],
       "exigences": []
     },
     {
@@ -241,6 +369,26 @@
       "niveauRequis": 10,
       "rangMax": 3,
       "effets": ["Vos sorts de feu ont 10/20/30% de chance d'appliquer un effet de brûlure infligeant des dégâts sur la durée."],
+      "triggeredEffects": [
+        {
+          "trigger": "on_hit",
+          "chance": [0.1, 0.2, 0.3],
+          "conditions": { "skill_damage_type": "fire" },
+          "effects": [
+            {
+              "type": "apply_debuff",
+              "debuff": {
+                "id": "embrasement_burn",
+                "name": "Brûlure",
+                "duration": 6,
+                "debuffType": "dot",
+                "damageType": "fire",
+                "totalDamage": { "source": "spell", "baseValue": 30 }
+              }
+            }
+          ]
+        }
+      ],
       "exigences": ["mage_feu_boule_de_feu_amelioree:1"]
     },
     {
@@ -261,6 +409,19 @@
       "niveauRequis": 50,
       "rangMax": 1,
       "effets": ["Vos coups critiques de feu réduisent le temps de recharge de vos autres sorts de 1 seconde."],
+      "triggeredEffects": [
+        {
+          "trigger": "on_critical_hit",
+          "chance": 1.0,
+          "conditions": { "skill_damage_type": "fire" },
+          "effects": [
+            {
+              "type": "reduce_cooldowns",
+              "value": 1000
+            }
+          ]
+        }
+      ],
       "exigences": ["mage_feu_critique_flamboyant:3"]
     },
     {
@@ -300,7 +461,15 @@
       "type": "passif",
       "niveauRequis": 10,
       "rangMax": 3,
-      "effets": ["Augmente votre maximum de points de vie de 3/6/9%."],
+      "effets": [
+        {
+          "type": "buff",
+          "buffType": "stat_modifier",
+          "statMods": [
+            { "stat": "PV", "modifier": "multiplicative", "value": [1.03, 1.06, 1.09] }
+          ]
+        }
+      ],
       "exigences": ["mage_givre_armure_de_givre:1"]
     },
     {
@@ -320,7 +489,15 @@
       "type": "passif",
       "niveauRequis": 10,
       "rangMax": 3,
-      "effets": ["Augmente les dégâts des sorts de givre de 5/10/15%."],
+      "effets": [
+        {
+          "type": "buff",
+          "buffType": "stat_modifier",
+          "statMods": [
+            { "stat": "IceDamageMultiplier", "modifier": "additive", "value": [0.05, 0.10, 0.15] }
+          ]
+        }
+      ],
       "exigences": ["mage_givre_eclair_de_givre_ameliore:1"]
     },
     {
@@ -410,7 +587,15 @@
       "type": "passif",
       "niveauRequis": 1,
       "rangMax": 5,
-      "effets": ["Augmente les chances de coup critique de 1/2/3/4/5%."],
+      "effets": [
+        {
+          "type": "buff",
+          "buffType": "stat_modifier",
+          "statMods": [
+            { "stat": "CritPct", "modifier": "additive", "value": [1, 2, 3, 4, 5] }
+          ]
+        }
+      ],
       "exigences": []
     },
     {
@@ -420,7 +605,15 @@
       "type": "passif",
       "niveauRequis": 10,
       "rangMax": 3,
-      "effets": ["Augmente les dégâts des coups critiques de 10/20/30%."],
+      "effets": [
+        {
+          "type": "buff",
+          "buffType": "stat_modifier",
+          "statMods": [
+            { "stat": "CritDmg", "modifier": "additive", "value": [10, 20, 30] }
+          ]
+        }
+      ],
       "exigences": ["rogue_assassinat_frappe_precise:1"]
     },
     {
@@ -430,7 +623,15 @@
       "type": "passif",
       "niveauRequis": 20,
       "rangMax": 5,
-      "effets": ["Augmente la vitesse d'attaque de 2/4/6/8/10%."],
+      "effets": [
+        {
+          "type": "buff",
+          "buffType": "stat_modifier",
+          "statMods": [
+            { "stat": "Vitesse", "modifier": "multiplicative", "value": [0.98, 0.96, 0.94, 0.92, 0.90] }
+          ]
+        }
+      ],
       "exigences": ["rogue_assassinat_point_faible:1"]
     },
     {
@@ -440,7 +641,18 @@
       "type": "passif",
       "niveauRequis": 50,
       "rangMax": 1,
-      "effets": ["Les attaques contre les cibles ayant moins de 35% de PV ont 25% de chances de coup critique supplémentaires."],
+      "effets": [],
+      "effects": [
+        {
+          "type": "conditional_stat_modifier",
+          "condition": {
+            "target_hp_less_than": 35
+          },
+          "statMods": [
+            { "stat": "CritPct", "modifier": "additive", "value": 25 }
+          ]
+        }
+      ],
       "exigences": ["rogue_assassinat_lames_rapides:3"]
     },
     {
@@ -451,6 +663,18 @@
       "niveauRequis": 100,
       "rangMax": 1,
       "effets": ["Vos coups critiques ont une chance de réinitialiser le temps de recharge de vos autres compétences."],
+      "triggeredEffects": [
+        {
+          "trigger": "on_critical_hit",
+          "chance": 0.2,
+          "effects": [
+            {
+              "type": "reduce_cooldowns",
+              "reset": true
+            }
+          ]
+        }
+      ],
       "exigences": ["rogue_assassinat_execution_sommaire:1"]
     },
     {
@@ -460,7 +684,15 @@
       "type": "passif",
       "niveauRequis": 1,
       "rangMax": 5,
-      "effets": ["Augmente l'esquive de 1/2/3/4/5%."],
+      "effets": [
+        {
+          "type": "buff",
+          "buffType": "stat_modifier",
+          "statMods": [
+            { "stat": "Esquive", "modifier": "additive", "value": [1, 2, 3, 4, 5] }
+          ]
+        }
+      ],
       "exigences": []
     },
     {
@@ -480,7 +712,7 @@
       "type": "passif",
       "niveauRequis": 10,
       "rangMax": 3,
-      "effets": ["Après avoir esquivé une attaque, votre prochaine attaque est 20/35/50% plus rapide."],
+      "description": ["Après avoir esquivé une attaque, votre prochaine attaque est 20/35/50% plus rapide."],
       "triggeredEffects": [
         {
             "trigger": "on_dodge",
@@ -517,7 +749,27 @@
       "type": "passif",
       "niveauRequis": 10,
       "rangMax": 3,
-      "effets": ["Esquiver une attaque augmente votre vitesse d'attaque de 5/10/15% pendant 5 secondes."],
+      "effets": [],
+      "triggeredEffects": [
+        {
+          "trigger": "on_dodge",
+          "chance": 1.0,
+          "effects": [
+            {
+              "type": "apply_buff",
+              "buff": {
+                "id": "roublardise_speed_buff",
+                "name": "Roublardise",
+                "duration": 5000,
+                "buffType": "stat_modifier",
+                "statMods": [
+                  { "stat": "Vitesse", "modifier": "multiplicative", "value": [0.95, 0.90, 0.85] }
+                ]
+              }
+            }
+          ]
+        }
+      ],
       "exigences": ["rogue_subtilite_insaisissable:1"]
     },
     {
@@ -557,7 +809,29 @@
       "type": "passif",
       "niveauRequis": 1,
       "rangMax": 5,
-      "effets": ["Vos attaques ont 10/15/20/25/30% de chance d'appliquer un poison qui inflige des dégâts sur la durée."],
+      "effets": [],
+      "triggeredEffects": [
+        {
+          "trigger": "on_hit",
+          "chance": [0.1, 0.15, 0.2, 0.25, 0.3],
+          "effects": [
+            {
+              "type": "apply_debuff",
+              "debuff": {
+                "id": "lames_empoisonnees_dot",
+                "name": "Poison (Lames)",
+                "duration": 8,
+                "debuffType": "dot",
+                "damageType": "nature",
+                "totalDamage": {
+                  "source": "attack_power",
+                  "multiplier": 0.8
+                }
+              }
+            }
+          ]
+        }
+      ],
       "exigences": []
     },
     {
@@ -607,7 +881,15 @@
       "type": "passif",
       "niveauRequis": 1,
       "rangMax": 5,
-      "effets": ["Augmente l'efficacité de vos soins de 5/10/15/20/25%."],
+      "effets": [
+        {
+          "type": "buff",
+          "buffType": "stat_modifier",
+          "statMods": [
+            { "stat": "HealingMultiplier", "modifier": "additive", "value": [0.05, 0.10, 0.15, 0.20, 0.25] }
+          ]
+        }
+      ],
       "exigences": []
     },
     {
@@ -657,7 +939,15 @@
       "type": "passif",
       "niveauRequis": 1,
       "rangMax": 5,
-      "effets": ["Augmente votre armure de 5/10/15/20/25%."],
+      "effets": [
+        {
+          "type": "buff",
+          "buffType": "stat_modifier",
+          "statMods": [
+            { "stat": "Armure", "modifier": "multiplicative", "value": [1.05, 1.10, 1.15, 1.20, 1.25] }
+          ]
+        }
+      ],
       "exigences": []
     },
     {
@@ -719,16 +1009,6 @@
       "rangMax": 1,
       "effets": ["Réduit tous les dégâts subis de 20% pendant 5 secondes après avoir utilisé un sort de soin sur vous-même."],
       "exigences": ["cleric_discipline_penitence:3", "cleric_discipline_egide_scintillante:3"]
-    },
-    {
-      "id": "cleric_discipline_dome_de_lumiere",
-      "nom": "Dôme de Lumière",
-      "classeId": "cleric",
-      "type": "passif",
-      "niveauRequis": 100,
-      "rangMax": 1,
-      "effets": ["Crée un dôme de lumière qui réduit les dégâts subis par vous de 50% pendant 10 secondes. Temps de recharge long."],
-      "exigences": ["cleric_discipline_suppression_de_la_douleur:1"]
     },
     {
       "id": "cleric_chatiment_jugement",
@@ -807,7 +1087,23 @@
       "type": "passif",
       "niveauRequis": 150,
       "rangMax": 1,
-      "effets": ["Vous ne pouvez pas mourir. Au lieu de cela, chaque coup mortel vous rend 25% de votre vie et augmente votre armure de 10% (cumulable)."],
+      "effets": [
+        {
+          "type": "cheat_death",
+          "heal_percent": 0.25,
+          "buff": {
+            "id": "immortal_colossus_armor_stack",
+            "name": "Colosse de Fer",
+            "duration": -1,
+            "is_stacking": true,
+            "max_stacks": 10,
+            "buffType": "stat_modifier",
+            "statMods": [
+              { "stat": "Armure", "modifier": "multiplicative", "value": 1.10 }
+            ]
+          }
+        }
+      ],
       "exigences": ["berserker_titan_dernier_rempart:1"]
     },
     {
@@ -817,7 +1113,18 @@
       "type": "passif",
       "niveauRequis": 150,
       "rangMax": 1,
-      "effets": ["En mourant, vous explosez en une nova de feu qui inflige d'énormes dégâts et vous ressuscitez avec la moitié de votre vie."],
+      "effets": [
+        {
+          "type": "on_death_resurrect",
+          "heal_percent": 0.5,
+          "aoe_damage": {
+            "type": "damage",
+            "damageType": "fire",
+            "source": "spell",
+            "baseValue": 500
+          }
+        }
+      ],
       "exigences": ["mage_feu_pyroclasme:1"]
     },
     {
@@ -827,7 +1134,23 @@
       "type": "passif",
       "niveauRequis": 150,
       "rangMax": 1,
-      "effets": ["Vous devenez un être de glace pure, immunisé aux effets de contrôle et vos sorts de givre gèlent instantanément les cibles."],
+      "effets": [],
+      "effects": [
+        {
+          "type": "buff",
+          "id": "coeur_de_l_hiver_buff",
+          "name": "Coeur de l'Hiver",
+          "duration": -1,
+          "buffType": "special"
+        },
+        {
+            "type": "buff",
+            "buffType": "stat_modifier",
+            "statMods": [
+                { "stat": "isImmuneToCC", "modifier": "additive", "value": 1 }
+            ]
+        }
+      ],
       "exigences": ["mage_givre_blizzard:1"]
     },
     {
@@ -857,7 +1180,21 @@
       "type": "passif",
       "niveauRequis": 150,
       "rangMax": 1,
-      "effets": ["Votre esquive atteint 90% et chaque esquive réussie riposte pour 100% des dégâts de votre arme."],
+      "effets": [
+        { "type": "stat_override", "stat": "Esquive", "value": 90 }
+      ],
+      "triggeredEffects": [
+        {
+          "trigger": "on_dodge",
+          "chance": 1.0,
+          "effects": [
+            {
+              "type": "riposte",
+              "damage_multiplier": 1.0
+            }
+          ]
+        }
+      ],
       "exigences": ["rogue_subtilite_disparition:1"]
     },
     {

--- a/src/features/combat/CombatView.tsx
+++ b/src/features/combat/CombatView.tsx
@@ -80,7 +80,7 @@ export function CombatView() {
   }
 
   if (enemies.length === 0 && killCount < currentDungeon.killTarget) {
-    return <div className="flex items-center justify-center h-screen">Recherche d'une cible...</div>;
+    return <div className="flex items-center justify-center h-screen">Recherche d&apos;une cible...</div>;
   }
 
   return (

--- a/src/features/quests/QuestsView.tsx
+++ b/src/features/quests/QuestsView.tsx
@@ -144,7 +144,7 @@ export function QuestsView() {
         const prevQuestId = `${questPrefix}_q${questNum - 1}`;
         return player.completedQuests.includes(prevQuestId);
     });
-  }, [gameData.quests, gameData.dungeons, player.completedQuests, player.completedDungeons, activeQuests]);
+  }, [gameData.quests, gameData.dungeons, player.completedQuests, player.completedDungeons, activeQuests, player.classeId]);
 
 
   return (

--- a/src/features/skills/SkillsView.tsx
+++ b/src/features/skills/SkillsView.tsx
@@ -148,7 +148,7 @@ export function SkillsView() {
                 </div>
 
                 <div className="flex-shrink-0">
-                    <h3 className="font-semibold mb-2 text-center">Barre d'Action</h3>
+                    <h3 className="font-semibold mb-2 text-center">Barre d&apos;Action</h3>
                      <Separator className="mb-4"/>
                     <div className="grid grid-cols-4 gap-2">
                         {equippedSkillsDetails.map((skill, index) => (

--- a/src/features/town/EnchanterView.tsx
+++ b/src/features/town/EnchanterView.tsx
@@ -102,7 +102,7 @@ const EnchantTab: React.FC = () => {
             {/* Colonne centrale "Workbench" */}
             <div className="md:col-span-2">
                 <Card>
-                    <CardHeader><CardTitle>Atelier d'Enchantement</CardTitle></CardHeader>
+                    <CardHeader><CardTitle>Atelier d&apos;Enchantement</CardTitle></CardHeader>
                     <CardContent className="space-y-4">
                         <div>
                             <h3 className="text-lg font-semibold mb-2">Objet à Enchanter</h3>

--- a/src/features/vendors/VendorsView.tsx
+++ b/src/features/vendors/VendorsView.tsx
@@ -79,7 +79,7 @@ function BuyRecipesTab() {
         } else {
             toast({
                 title: "Échec de l'achat",
-                description: "Vous n'avez pas assez d'or, de réputation, ou connaissez déjà cette recette.",
+                description: "Vous n&apos;avez pas assez d&apos;or, de réputation, ou connaissez déjà cette recette.",
                 variant: 'destructive'
             });
         }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -75,6 +75,9 @@ export interface Buff {
     name: string;
     duration: number;
     value?: any;
+    stacks?: number;
+    is_stacking?: boolean;
+    max_stacks?: number;
     healingPerTick?: number;
     tickInterval?: number;
     nextTickIn?: number;
@@ -87,10 +90,14 @@ export interface Debuff {
     id:string;
     name: string;
     duration: number;
+    isDebuff?: boolean;
+    stacks?: number;
     damagePerTick?: number;
     tickInterval?: number;
     nextTickIn?: number;
+    num_ticks?: number;
     statMods?: StatMod[];
+    damageType?: Theme;
 }
 
 export interface PlayerState {
@@ -125,6 +132,8 @@ export interface PlayerState {
   invulnerabilityDuration: number;
   stunDuration: number;
   form: string | null;
+  isImmuneToCC: boolean;
+  nextAttackIsGuaranteedCrit: boolean;
 }
 
 export interface InventoryState {
@@ -156,17 +165,19 @@ export type CombatEnemy = Monstre & {
     attackProgress: number;
     templateId: string;
     activeDebuffs: Debuff[];
+    activeBuffs: Buff[];
     stunDuration: number;
     elementalDamage?: {
         type: Theme;
         min: number;
         max: number;
     };
+    abilities?: any[];
 };
 
 export interface CombatLogEntry {
     message: string;
-    type: 'player_attack' | 'enemy_attack' | 'crit' | 'loot' | 'info' | 'flee' | 'levelup' | 'heal' | 'quest' | 'shield' | 'poison_proc';
+    type: 'player_attack' | 'enemy_attack' | 'crit' | 'loot' | 'info' | 'flee' | 'levelup' | 'heal' | 'quest' | 'shield' | 'poison_proc' | 'talent_proc';
     timestamp: number;
     item?: Item;
 }
@@ -176,6 +187,7 @@ export interface CombatState {
   playerAttackInterval: number; // in ms
   playerAttackProgress: number; // 0 to 1
   skillCooldowns: { [skillId: string]: number }; // { skillId: remainingTimeInMs }
+  monsterSkillCooldowns: { [monsterSkillId: string]: number };
   killCount: number;
   log: CombatLogEntry[];
   autoAttack: boolean;
@@ -185,6 +197,7 @@ export interface CombatState {
   pendingActions: any[];
   goldGained: number;
   xpGained: number;
+  ultimateTalentUsed: boolean;
 }
 
 export interface ItemGenerationContext {


### PR DESCRIPTION
This commit delivers a set of high-impact gameplay features and quality-of-life improvements based on a prioritized plan.

Key implementations:
- **On-Hit/On-Dodge Triggers:** The talent system now supports effects that trigger on hit and on dodge. This has been used to implement the following talents:
  - `berserker_fureur_enrage` (stacking attack speed on hit)
  - `rogue_poison_lames_empoisonnees` (poison DoT on hit)
  - `rogue_subtilite_roublardise` (attack speed buff on dodge)
- **Cheat Death Mechanic:** The `berserker_titan_dernier_rempart` talent now correctly allows the player to survive a fatal blow with 1 HP once per combat.
- **Conditional Stats:** A basic framework for conditional stats has been added to support the `rogue_assassinat_execution_sommaire` talent, granting bonus crit chance against low-health targets.
- **Data and Logic Refactoring:**
  - The `cleric_discipline_dome_de_lumiere` talent has been correctly refactored into an active skill.
  - Resource cost calculation has been centralized into a single `getSkillResourceCost` function in `formulas.ts` to ensure consistency.
  - Obsolete fallback logic has been removed from `skillProcessor.ts`.
  - The management of heroic dungeons has been improved by adding a `heroicVersionId` to the data, removing the need for string manipulation in the UI.

All associated type definitions and logic have been updated, and the project passes all `npm run lint` and `npm run typecheck` commands.