### PR TITLE
Fix: Resolve game freeze in dungeons

### DIFF
--- a/src/features/combat/CombatView.tsx
+++ b/src/features/combat/CombatView.tsx
@@ -3,7 +3,7 @@ import { useGameStore } from '@/state/gameStore';
 import { Button } from '@/components/ui/button';
 import { CombatLog } from './components/CombatLog';
 import EntityDisplay from './components/EntityDisplay';
-import { useEffect, useMemo } from 'react';
+import { useMemo } from 'react'; // AMÉLIORATION: 'useEffect' supprimé car il n'est plus utilisé ici
 import { ArrowLeft } from 'lucide-react';
 import { ActionStrip } from './components/ActionStrip';
 import type { Skill } from '@/lib/types';
@@ -63,18 +63,13 @@ export function CombatView() {
       .filter((t): t is Skill => t !== null);
   }, [player?.equippedSkills, gameData.skills]);
 
-  useEffect(() => {
-    if (enemies && enemies.length === 0 && currentDungeon) {
-      if (killCount < currentDungeon.killTarget) {
-        startCombat();
-      }
-    }
-  }, [enemies, startCombat, killCount, currentDungeon]);
-  
+  // SUPPRIMÉ: Le bloc useEffect a été retiré pour corriger la boucle infinie.
+  // La logique de démarrage de combat est maintenant entièrement gérée dans handleEnemyDeath.
+
   const handleCycleTarget = () => {
     cycleTarget();
   };
-  
+
   if (!currentDungeon) {
     return <div className="flex items-center justify-center h-screen">Chargement du donjon...</div>;
   }

--- a/src/state/gameStore.ts
+++ b/src/state/gameStore.ts
@@ -1932,17 +1932,20 @@ export const useGameStore = create<GameState>()(
       },
 
       activateSkill: (skillId: string) => {
+        let deadEnemyIds: string[] = [];
         set((state: GameState) => {
-            const { deadEnemyIds } = processSkill(state, skillId, get, get().applySpecialEffect);
-            if (deadEnemyIds.length > 0) {
-                deadEnemyIds.forEach(enemyId => {
-                    const enemy = get().combat.enemies.find(e => e.id === enemyId);
-                    if (enemy) {
-                        get().handleEnemyDeath(enemy, skillId);
-                    }
-                });
-            }
+            const result = processSkill(state, skillId, get, get().applySpecialEffect);
+            deadEnemyIds = result.deadEnemyIds;
         });
+
+        if (deadEnemyIds.length > 0) {
+            deadEnemyIds.forEach(enemyId => {
+                const enemy = get().combat.enemies.find(e => e.id === enemyId);
+                if (enemy) {
+                    get().handleEnemyDeath(enemy, skillId);
+                }
+            });
+        }
       },
 
       enemyAttacks: () => {


### PR DESCRIPTION
This commit addresses a bug where the game would freeze after killing one or two monsters in a dungeon.

The root cause was a race condition and improper state handling in the `gameStore`. When a skill would kill multiple enemies, the `activateSkill` function would call `handleEnemyDeath` from within a `set` call, which is an anti-pattern in Zustand and led to nested, unsafe state updates. This could cause an infinite loop when combined with the `setTimeout` in `handleEnemyDeath` that starts the next combat.

The fix consists of two parts:
1.  Refactored the `activateSkill` function in `src/state/gameStore.ts` to correctly sequence state updates. The logic for handling enemy deaths is now called after the main state update is complete, preventing the race condition.
2.  Removed a redundant and dangerous `useEffect` from `src/features/combat/CombatView.tsx`. This effect was another potential source of infinite loops and was made obsolete by the logic in `handleEnemyDeath`.

These two changes together ensure that the combat flow is robust and that the game state remains consistent, resolving the freezing issue.