### PR TITLE
Fix: Correct behavior for Arcane Missiles, Frost Spells, and Mana Shield

### DIFF
--- a/src/state/gameStore.ts
+++ b/src/state/gameStore.ts
@@ -1708,7 +1708,8 @@ export const useGameStore = create<GameState>()(
                     if (enemy.stunDuration > 0) {
                         enemy.stunDuration -= delta;
                     } else {
-                        const attackInterval = enemy.stats.Vitesse * 1000;
+                        const modifiedStats = getModifiedStats(enemy.stats, enemy.activeDebuffs || []);
+                        const attackInterval = modifiedStats.Vitesse * 1000;
                         if (enemy.attackProgress < 1) {
                             enemy.attackProgress += delta / attackInterval;
                         } else {
@@ -2096,9 +2097,10 @@ export const useGameStore = create<GameState>()(
                         const actualManaDrained = Math.min(manaDrain, state.player.resources.current);
 
                         state.player.resources.current -= actualManaDrained;
-                        shieldAbsorption -= (manaDrain - actualManaDrained);
 
-                        state.combat.log.push({ message: `Votre bouclier convertit ${actualManaDrained} dégâts en perte de mana.`, type: 'shield', timestamp: Date.now() });
+                        if (manaDrain > 0) {
+                            state.combat.log.push({ message: `Votre bouclier convertit ${actualManaDrained} dégâts en perte de mana.`, type: 'shield', timestamp: Date.now() });
+                        }
                     }
 
                     state.player.shield -= shieldAbsorption;


### PR DESCRIPTION
This commit addresses three separate bugs related to skill functionality:

1.  **Arcane Missiles Not Working**: The `multi_strike` logic in `skillProcessor.ts` was not correctly handling ranked skills where the number of strikes is an array. This has been fixed by using the `getRankValue` helper function, so Arcane Missiles now fires the correct number of projectiles.

2.  **Frost Spells Not Slowing**: This was a two-part issue. First, `skillProcessor.ts` was not applying `stat_modifier` debuffs (like slows). Second, the `gameTick` function in `gameStore.ts` was not using the enemy's modified stats to calculate attack speed. Both issues have been resolved. Debuffs are now applied correctly, and the game logic now accounts for them, making slows effective.

3.  **Mana Shield Not Working**: This was also a two-part issue. First, `skillProcessor.ts` did not handle the `shield` effect type, so the shield value was never applied to the player. Second, the damage absorption logic in `enemyAttacks` in `gameStore.ts` was flawed, reducing the shield's effectiveness if the player was low on mana. Both parts have been fixed. The skill now correctly grants a shield, and the shield absorbs the proper amount of damage regardless of the player's mana.