### PR TITLE
Fix: Audit and fix numerous broken skills and logic gaps

### DIFF
--- a/public/data/skills.json
+++ b/public/data/skills.json
@@ -757,6 +757,16 @@
             "effets": [
                 "Vous vous fondez dans l'ombre, empêchant les ennemis de vous attaquer. Dure 10 secondes ou jusqu'à ce que vous attaquiez.",
                 "Coûte 20 Énergie."
+            ],
+            "effects": [
+                {
+                    "type": "buff",
+                    "id": "stealth",
+                    "name": "Camouflé",
+                    "duration": 10,
+                    "buffType": "special"
+                },
+                { "type": "resource_cost", "amount": 20 }
             ]
         },
         {
@@ -808,6 +818,16 @@
             "effets": [
                 "Attaque avec les deux armes, infligeant 100% des dégâts de l'arme + 10.",
                 "Coûte 40 Énergie."
+            ],
+            "effects": [
+                {
+                    "type": "damage",
+                    "damageType": "physical",
+                    "source": "weapon",
+                    "multiplier": 1.0,
+                    "bonus_flat_damage": 10
+                },
+                { "type": "resource_cost", "amount": 40 }
             ]
         },
         {
@@ -1120,6 +1140,11 @@
             "effets": [
                 "Inflige 40 dégâts d'Ombre et étourdit la cible pendant 3s.",
                 "Coûte 20 Mana."
+            ],
+            "effects": [
+                { "type": "damage", "damageType": "shadow", "source": "spell", "baseValue": 40 },
+                { "type": "debuff", "debuffType": "cc", "id": "mind_blast_stun", "name": "Étourdissement", "duration": 3, "ccType": "stun" },
+                { "type": "resource_cost", "amount": 20 }
             ],
             "cooldown": 15
         },


### PR DESCRIPTION
This commit is the result of a comprehensive audit of the skill system, prompted by several bug reports. It fixes a wide range of issues, making many previously non-functional skills work as intended.

The main changes are in `src/core/skillProcessor.ts`:
- Added logic to handle several previously unimplemented skill effect types: `shield`, `invulnerability`, `death_ward`, and `cc` (stun) debuffs.
- Corrected the logic for `multi_strike` effects to properly handle ranked skills.
- Added logic to correctly apply `stat_modifier` debuffs (e.g., slows).
- Added special handling for the `stealth` buff to correctly update the combat state.

Additionally, `public/data/skills.json` has been updated:
- Added `effects` arrays to several skills that were missing them, making them functional for the first time. This includes skills for the Cleric, Rogue, and Mage.

Finally, `src/state/gameStore.ts` was also improved:
- The `gameTick` function now correctly applies enemy debuffs when calculating their attack speed.
- The Mana Shield damage absorption logic in `enemyAttacks` has been corrected.

This overhaul addresses the reported bugs for Arcane Missiles, Frost Spells, and Mana Shield, and proactively fixes many other skills that were silently failing.