### PR TITLE
Fix: Prevent crash when learning talents with invalid data

### DIFF
--- a/public/data/talents.json
+++ b/public/data/talents.json
@@ -143,7 +143,7 @@
       "type": "passif",
       "niveauRequis": 50,
       "rangMax": 1,
-      "effets": [{
+      "effects": [{
         "type": "buff", "buffType": "stat_modifier",
         "statMods": [
             { "stat": "DamageMultiplier", "modifier": "additive", "value": 0.15, "condition": { "requires_weapon_type": "two_handed" } },
@@ -159,7 +159,7 @@
       "type": "passif",
       "niveauRequis": 100,
       "rangMax": 1,
-      "effets": [{
+      "effects": [{
           "type": "buff", "buffType": "stat_modifier",
           "statMods": [{ "stat": "DamageMultiplier", "modifier": "additive", "value": 0.5, "condition": { "target_hp_less_than": 20 } }]
       }],

--- a/src/state/gameStore.ts
+++ b/src/state/gameStore.ts
@@ -315,6 +315,10 @@ const generateEquipmentLoot = (monster: Monstre, gameData: GameData, playerClass
 };
 
 const getTalentEffectValue = (effect: string, rank: number): number => {
+    if (typeof effect !== 'string') {
+        console.error("Invalid talent effect format: expected a string, but got", typeof effect);
+        return 0;
+    }
     const matches = effect.match(/([\d./]+)/);
     if (!matches) return 0;
     const values = matches[1].split('/').map(Number);


### PR DESCRIPTION
This commit addresses a runtime error that occurred when spending a talent point. The error, `effect.match is not a function`, was caused by malformed data in `talents.json` and a lack of defensive programming in the function that processes talent effects.

The fix consists of two parts:
1.  **Safeguard in `getTalentEffectValue`**: A type check has been added to the `getTalentEffectValue` function in `src/state/gameStore.ts`. This ensures that the function will not crash if it receives a non-string value from the talent data, making the system more robust against data errors.
2.  **Data Correction in `talents.json`**: The two talents that were causing the crash (`berserker_armes_maitrise_deux_mains` and `berserker_armes_execution`) have been corrected. The property `effets` was incorrectly used instead of `effects`, causing the game to try to process an object as a string.

These changes resolve the crash and improve the overall stability of the talent system.