### PR TITLE
Fix: Prevent talent crash and correct data

### DIFF
--- a/public/data/talents.json
+++ b/public/data/talents.json
@@ -8,7 +8,7 @@
       "type": "passif",
       "niveauRequis": 1,
       "rangMax": 5,
-      "effets": [
+      "effects": [
         {
           "type": "buff",
           "buffType": "stat_modifier",
@@ -27,7 +27,7 @@
       "type": "passif",
       "niveauRequis": 1,
       "rangMax": 5,
-      "effets": [
+      "effects": [
         {
           "type": "buff",
           "buffType": "stat_modifier",
@@ -45,7 +45,7 @@
       "type": "passif",
       "niveauRequis": 10,
       "rangMax": 3,
-      "effets": [
+      "effects": [
         {
           "type": "buff",
           "buffType": "stat_modifier",
@@ -172,7 +172,7 @@
       "type": "passif",
       "niveauRequis": 1,
       "rangMax": 5,
-      "effets": [
+      "effects": [
         {
           "type": "buff",
           "buffType": "stat_modifier",
@@ -222,7 +222,7 @@
       "type": "passif",
       "niveauRequis": 20,
       "rangMax": 5,
-      "effets": [
+      "effects": [
         {
           "type": "buff",
           "buffType": "stat_modifier",
@@ -260,7 +260,7 @@
       "type": "passif",
       "niveauRequis": 1,
       "rangMax": 5,
-      "effets": [
+      "effects": [
         {
           "type": "buff",
           "buffType": "stat_modifier",
@@ -300,7 +300,7 @@
       "type": "passif",
       "niveauRequis": 20,
       "rangMax": 5,
-      "effets": [
+      "effects": [
         {
           "type": "buff",
           "buffType": "stat_modifier",
@@ -461,7 +461,7 @@
       "type": "passif",
       "niveauRequis": 10,
       "rangMax": 3,
-      "effets": [
+      "effects": [
         {
           "type": "buff",
           "buffType": "stat_modifier",
@@ -489,7 +489,7 @@
       "type": "passif",
       "niveauRequis": 10,
       "rangMax": 3,
-      "effets": [
+      "effects": [
         {
           "type": "buff",
           "buffType": "stat_modifier",
@@ -587,7 +587,7 @@
       "type": "passif",
       "niveauRequis": 1,
       "rangMax": 5,
-      "effets": [
+      "effects": [
         {
           "type": "buff",
           "buffType": "stat_modifier",
@@ -605,7 +605,7 @@
       "type": "passif",
       "niveauRequis": 10,
       "rangMax": 3,
-      "effets": [
+      "effects": [
         {
           "type": "buff",
           "buffType": "stat_modifier",
@@ -623,7 +623,7 @@
       "type": "passif",
       "niveauRequis": 20,
       "rangMax": 5,
-      "effets": [
+      "effects": [
         {
           "type": "buff",
           "buffType": "stat_modifier",
@@ -684,7 +684,7 @@
       "type": "passif",
       "niveauRequis": 1,
       "rangMax": 5,
-      "effets": [
+      "effects": [
         {
           "type": "buff",
           "buffType": "stat_modifier",
@@ -881,7 +881,7 @@
       "type": "passif",
       "niveauRequis": 1,
       "rangMax": 5,
-      "effets": [
+      "effects": [
         {
           "type": "buff",
           "buffType": "stat_modifier",
@@ -939,7 +939,7 @@
       "type": "passif",
       "niveauRequis": 1,
       "rangMax": 5,
-      "effets": [
+      "effects": [
         {
           "type": "buff",
           "buffType": "stat_modifier",

--- a/src/state/gameStore.ts
+++ b/src/state/gameStore.ts
@@ -1031,6 +1031,11 @@ export const useGameStore = create<GameState>()(
                 });
               } else { // Fallback to old effect strings
                 talentData.effets.forEach(effectString => {
+                    if (typeof effectString !== 'string') {
+                        // This talent is using the new object format but under the old 'effets' key.
+                        // The safeguard in getTalentEffectValue will log an error. Skip processing here.
+                        return;
+                    }
                     const value = getTalentEffectValue(effectString, rank);
                     if (effectString.includes('Armure') && typeof player.stats.Armure === 'number') {
                         player.stats.Armure += (player.stats.Armure * value) / 100;


### PR DESCRIPTION
This commit addresses a runtime error that occurred when spending a talent point. The error, `effect.match is not a function`, was caused by malformed data in `talents.json` and a lack of defensive programming in the function that processes talent effects.

The fix consists of two parts:
1.  **Safeguard in `recalculateStats`**: An improved type check has been added to the loop that processes old-style talent `effets` in `src/state/gameStore.ts`. This ensures that the function will not crash if it receives a non-string value from the talent data, making the system more robust against data errors.
2.  **Data Correction in `talents.json`**: A comprehensive audit of `talents.json` was performed. All talents that were incorrectly using the `effets` property with an array of objects have been corrected to use the `effects` property. This resolves the root cause of the crash.

These changes resolve the crash and improve the overall stability of the talent system.