### PR TITLE
fix: HoT and XP/level up bugs

### DIFF
--- a/public/data/skills.json
+++ b/public/data/skills.json
@@ -1074,6 +1074,7 @@
                     "id": "renew_hot",
                     "name": "Rénovation",
                     "duration": 12,
+                    "buffType": "hot",
                     "totalHealing": {
                         "source": "base_value",
                         "multiplier": 30
@@ -1102,7 +1103,7 @@
                     "type": "buff",
                     "id": "prayer_of_healing_hot",
                     "name": "Prière de guérison",
-                    "duration": 12000,
+                    "duration": 12,
                     "buffType": "hot",
                     "totalHealing": {
                         "source": "base_value",

--- a/src/state/gameStore.ts
+++ b/src/state/gameStore.ts
@@ -1797,6 +1797,7 @@ export const useGameStore = create<GameState>()(
             const enemy = get().combat.enemies.find(e => e.id === id);
             if(enemy) get().handleEnemyDeath(enemy);
           });
+          get().checkAndApplyLevelUp();
       },
 
       playerAttack: (targetId: string, isCleave = false, skillId?: string) => {


### PR DESCRIPTION
This commit addresses two critical bugs reported by the user:

1.  **Fix(HoT):** The Heal over Time (HoT) effects were still not working. This was due to a missing `buffType: 'hot'` property in one of the skill definitions and inconsistent `duration` values in the data. The skill data has been corrected, and the logic in `skillProcessor.ts` has been confirmed to be correct.
2.  **Fix(XP):** The player was not leveling up inside dungeons. This was because the level up check was not being called frequently enough. A call to `checkAndApplyLevelUp` has been added to the `gameTick` function to ensure level ups are processed as soon as the XP threshold is met.

This commit builds upon the previous UI enhancements and bug fixes.