### PR TITLE
fix: Make initial enchanting recipes available without reputation

### DIFF
--- a/public/data/enchantments.json
+++ b/public/data/enchantments.json
@@ -3,22 +3,19 @@
     "id": "enchant_minor_strength",
     "name": "Ench. Mineur (Force)",
     "tier": 1, "level": 5, "description": "+2 Force.", "affixRef": "Force_2",
-    "cost": [ { "id": "strange_dust", "amount": 1 } ], "source": ["vendor"],
-    "reputationRequirement": { "factionId": "silver_guardians", "rankName": "Amical", "threshold": 1000 }
+    "cost": [ { "id": "strange_dust", "amount": 1 } ], "source": ["vendor"]
   },
   {
     "id": "enchant_minor_intellect",
     "name": "Ench. Mineur (Intelligence)",
     "tier": 1, "level": 5, "description": "+2 Intelligence.", "affixRef": "Intelligence_2",
-    "cost": [ { "id": "strange_dust", "amount": 1 } ], "source": ["vendor"],
-    "reputationRequirement": { "factionId": "silver_guardians", "rankName": "Amical", "threshold": 1000 }
+    "cost": [ { "id": "strange_dust", "amount": 1 } ], "source": ["vendor"]
   },
   {
     "id": "enchant_minor_stamina",
     "name": "Ench. Mineur (Endurance)",
     "tier": 1, "level": 5, "description": "+5 PV.", "affixRef": "PV_5",
-    "cost": [ { "id": "strange_dust", "amount": 1 } ], "source": ["vendor"],
-    "reputationRequirement": { "factionId": "silver_guardians", "rankName": "Amical", "threshold": 1000 }
+    "cost": [ { "id": "strange_dust", "amount": 1 } ], "source": ["vendor"]
   },
   {
     "id": "enchant_minor_armor",


### PR DESCRIPTION
This commit fixes an issue where new players could not see any enchanting recipes because they were all locked behind a reputation wall.

The `reputationRequirement` has been removed from the initial "minor" recipes, making them available for purchase from the vendor at the start of the game.