### PR TITLE
Fix: Make initial enchantment recipes available at level 1

### DIFF
--- a/public/data/enchantments.json
+++ b/public/data/enchantments.json
@@ -2,19 +2,19 @@
   {
     "id": "enchant_minor_strength",
     "name": "Ench. Mineur (Force)",
-    "tier": 1, "level": 5, "description": "+2 Force.", "affixRef": "Force_2",
+    "tier": 1, "level": 1, "description": "+2 Force.", "affixRef": "Force_2",
     "cost": [ { "id": "strange_dust", "amount": 1 } ], "source": ["vendor"]
   },
   {
     "id": "enchant_minor_intellect",
     "name": "Ench. Mineur (Intelligence)",
-    "tier": 1, "level": 5, "description": "+2 Intelligence.", "affixRef": "Intelligence_2",
+    "tier": 1, "level": 1, "description": "+2 Intelligence.", "affixRef": "Intelligence_2",
     "cost": [ { "id": "strange_dust", "amount": 1 } ], "source": ["vendor"]
   },
   {
     "id": "enchant_minor_stamina",
     "name": "Ench. Mineur (Endurance)",
-    "tier": 1, "level": 5, "description": "+5 PV.", "affixRef": "PV_5",
+    "tier": 1, "level": 1, "description": "+5 PV.", "affixRef": "PV_5",
     "cost": [ { "id": "strange_dust", "amount": 1 } ], "source": ["vendor"]
   },
   {


### PR DESCRIPTION
The enchantment recipes were not visible to new players because the player starts at level 1, but the lowest level enchantment recipe required level 5. This resulted in an empty vendor list, which the user perceived as a bug.

This change lowers the level requirement for the three initial "minor" enchantment recipes from 5 to 1, making them available to new players from the start.