### PR TITLE
fix: Correct undefined variable in VendorsView

### DIFF
--- a/src/features/vendors/VendorsView.tsx
+++ b/src/features/vendors/VendorsView.tsx
@@ -130,7 +130,7 @@ function BuyRecipesTab() {
                                 const sortedRanks = [...faction.ranks].sort((a, b) => a.threshold - b.threshold);
                                 const requiredRank = sortedRanks.find(r => repReq.threshold === r.threshold);
                                 if (requiredRank) repInfo.rankName = requiredRank.name;
-                                repInfo.currentRepValue = playerReputation[repReq.factionId]?.value || 0;
+                                repInfo.currentRepValue = player.reputation[repReq.factionId]?.value || 0;
                                 const currentRank = sortedRanks.slice().reverse().find(r => repInfo.currentRepValue >= r.threshold);
                                 repInfo.currentRankName = currentRank ? currentRank.name : 'Inconnu';
                                 const nextRank = sortedRanks.find(r => repInfo.currentRepValue < r.threshold);


### PR DESCRIPTION
This commit fixes a runtime error in the `VendorsView.tsx` component.

The error `playerReputation is not defined` was caused by referencing a variable that did not exist. The fix replaces the incorrect variable `playerReputation` with the correctly scoped and populated `player.reputation` object, which is available from the `useGameStore`.

This ensures the UI can correctly display reputation requirements and player progress for vendor recipes.