### PR TITLE
fix: Round recipe price display in vendor view

### DIFF
--- a/src/features/vendors/VendorsView.tsx
+++ b/src/features/vendors/VendorsView.tsx
@@ -154,7 +154,7 @@ function BuyRecipesTab() {
                                         </div>
                                     )}
                                 </TableCell>
-                                <TableCell className="text-right font-mono text-primary">{recipe.price}</TableCell>
+                                <TableCell className="text-right font-mono text-primary">{Math.round(recipe.price)}</TableCell>
                                 <TableCell className="text-right">
                                     <Button size="sm" variant="outline" onClick={() => handleBuyRecipe(recipe)} disabled={!recipe.canLearn}>
                                         <BookUp className="mr-2 h-4 w-4" /> Apprendre


### PR DESCRIPTION
This commit fixes a floating-point display issue where recipe prices were showing long, unreadable decimal values (e.g., 440.00000000000006).

The fix applies `Math.round()` to the `recipe.price` value before it is rendered in the `BuyRecipesTab` component within `VendorsView.tsx`, ensuring that prices are always displayed as clean integers.