### PR TITLE
Fix(gameStore): Handle undefined 'effets' property

### DIFF
--- a/src/data/schemas.ts
+++ b/src/data/schemas.ts
@@ -240,7 +240,7 @@ const BaseSkillTalentSchema = z.object({
   type: z.enum(["actif", "passif"]),
   niveauRequis: z.number().int().optional(),
   rangMax: z.number().int(),
-  effets: z.array(z.string()),
+  effets: z.array(z.string()).optional(),
   effects: z.array(SkillEffectSchema).optional(),
   exigences: z.array(z.string()).default([]),
 });

--- a/src/features/combat/components/FloatingCombatText.tsx
+++ b/src/features/combat/components/FloatingCombatText.tsx
@@ -19,6 +19,7 @@ const typeColors: Record<FloatingTextType, string> = {
   buff: 'text-blue-400',
   debuff: 'text-orange-400',
   info: 'text-white',
+  shield: 'text-cyan-400',
 };
 
 export function FloatingCombatText({ text, type, onAnimationEnd }: FloatingCombatTextProps) {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -184,7 +184,7 @@ export interface CombatLogEntry {
     item?: Item;
 }
 
-export type FloatingTextType = 'damage' | 'crit' | 'heal' | 'dodge' | 'miss' | 'buff' | 'debuff' | 'info';
+export type FloatingTextType = 'damage' | 'crit' | 'heal' | 'dodge' | 'miss' | 'buff' | 'debuff' | 'info' | 'shield';
 
 export interface FloatingText {
   id: string;

--- a/src/state/gameStore.ts
+++ b/src/state/gameStore.ts
@@ -1080,19 +1080,21 @@ export const useGameStore = create<GameState>()(
                     }
                 });
               } else { // Fallback to old effect strings
-                talentData.effets.forEach(effectString => {
-                    if (typeof effectString !== 'string') {
-                        // This talent is using the new object format but under the old 'effets' key.
-                        // The safeguard in getTalentEffectValue will log an error. Skip processing here.
-                        return;
-                    }
-                    const value = getTalentEffectValue(effectString, rank);
-                    if (effectString.includes('Armure') && typeof player.stats.Armure === 'number') {
-                        player.stats.Armure += (player.stats.Armure * value) / 100;
-                    } else if (effectString.includes('PV') && typeof player.stats.PV === 'number') {
-                        player.stats.PV += (player.baseStats.PV * value) / 100;
-                    } // ... and so on for other stats, always with type checks
-                });
+                if (talentData.effets) {
+                  talentData.effets.forEach(effectString => {
+                      if (typeof effectString !== 'string') {
+                          // This talent is using the new object format but under the old 'effets' key.
+                          // The safeguard in getTalentEffectValue will log an error. Skip processing here.
+                          return;
+                      }
+                      const value = getTalentEffectValue(effectString, rank);
+                      if (effectString.includes('Armure') && typeof player.stats.Armure === 'number') {
+                          player.stats.Armure += (player.stats.Armure * value) / 100;
+                      } else if (effectString.includes('PV') && typeof player.stats.PV === 'number') {
+                          player.stats.PV += (player.baseStats.PV * value) / 100;
+                      } // ... and so on for other stats, always with type checks
+                  });
+                }
               }
           });
 
@@ -1856,7 +1858,7 @@ export const useGameStore = create<GameState>()(
                             const mitigatedDamage = Math.round(finalDamage * (1 - dr));
 
                             target.stats.PV -= mitigatedDamage;
-                            const waveNum = getTalentEffectValue(skill!.effets[0], state.player.learnedSkills[skill!.id]) - action.wavesLeft + 1;
+                            const waveNum = skill?.effets ? getTalentEffectValue(skill.effets[0], state.player.learnedSkills[skill.id]) - action.wavesLeft + 1 : 0;
                             const msg = `Votre ${skill!.nom} (Vague ${waveNum}) inflige ${mitigatedDamage} points de dégâts à ${target.nom}.`;
                             const critMsg = `CRITIQUE ! Votre ${skill!.nom} (Vague ${waveNum}) inflige ${mitigatedDamage} points de dégâts à ${target.nom}.`;
                             state.combat.log.push({ message: isCrit ? critMsg : msg, type: isCrit ? 'crit' : 'player_attack', timestamp: Date.now() });
@@ -1981,7 +1983,7 @@ export const useGameStore = create<GameState>()(
               const criDeGuerreRank = state.player.learnedTalents['berserker_battle_cry'] || 0;
               if (criDeGuerreRank > 0) {
                   const talent = state.gameData.talents.find(t => t.id === 'berserker_battle_cry');
-                  if(talent) rageGained += getTalentEffectValue(talent.effets[0], criDeGuerreRank);
+                  if(talent && talent.effets) rageGained += getTalentEffectValue(talent.effets[0], criDeGuerreRank);
               }
               state.player.resources.current = Math.min(state.player.resources.max, state.player.resources.current + rageGained);
             }


### PR DESCRIPTION
This commit addresses a runtime error `TypeError: Cannot read properties of undefined (reading 'forEach')` that occurred in `src/state/gameStore.ts`.

The error was caused by an incorrect assumption that `talentData.effets` would always be present if `talentData.effects` was not. This led to a crash when the code attempted to call `forEach` on an undefined value.

The following changes have been made:
- Made the `effets` property optional in `BaseSkillTalentSchema` in `src/data/schemas.ts` to accurately reflect the data.
- Added a defensive check in `recalculateStats` in `src/state/gameStore.ts` to ensure `talentData.effets` exists before iteration.
- Added similar null checks for `talent.effets` and `skill.effets` in other parts of `gameStore.ts` that were flagged by the type checker after the schema change.
- Resolved a follow-up type error by adding a `shield` type to `FloatingTextType` and its corresponding color in `FloatingCombatText.tsx`.