### PR TITLE
Feat(talents): Enhance talent descriptions to show multi-rank effects

### DIFF
--- a/src/data/schemas.ts
+++ b/src/data/schemas.ts
@@ -238,6 +238,7 @@ const BaseSkillTalentSchema = z.object({
   nom: z.string(),
   classeId: z.string(),
   type: z.enum(["actif", "passif"]),
+  description: z.string().optional(),
   niveauRequis: z.number().int().optional(),
   rangMax: z.number().int(),
   effets: z.array(z.string()).optional(),


### PR DESCRIPTION
This commit significantly improves the talent description system to provide more detailed and useful information to the player.

The `Talent` schema in `src/data/schemas.ts` has been updated to include an optional `description` field for manually authored descriptions. The `TalentsView.tsx` component has been refactored to dynamically generate comprehensive talent descriptions from the structured effect data in `talents.json`. The new description logic handles various effect types, including stat modifiers, on-hit effects, and skill modifications.

The talent popover now displays:
1. The effect for the current rank.
2. The effect for the next rank.
3. A full description showing the scaling effect across all ranks (e.g., "Increases Attack Speed by 2/4/6/8/10%").

This addresses the user feedback that talent descriptions were unclear and lacked information about how they scale with rank.