### PR TITLE
Ce commit inclut une refonte de la compétence de poison du voleur, un…

### DIFF
--- a/public/data/items.json
+++ b/public/data/items.json
@@ -1107,6 +1107,38 @@
       { "id": "set_cleric_t3_belt", "baseId": "set_cleric_t3_belt", "name": "Ceinture du Dévoué Exalté", "slot": "belt", "niveauMin": 39, "rarity": "Légendaire", "affixes": [{"ref": "Armure", "val": 60}, {"ref": "Esprit", "val": 18}, {"ref": "RessourceMax", "val": 80}], "tagsClasse": ["cleric"], "tier": 3, "set": { "id": "cleric_devotion_set", "name": "Habits du Dévoué" } },
       { "id": "set_cleric_t3_legs", "baseId": "set_cleric_t3_legs", "name": "Jambières du Dévoué Exalté", "slot": "legs", "niveauMin": 41, "rarity": "Légendaire", "affixes": [{"ref": "Armure", "val": 150}, {"ref": "Esprit", "val": 32}, {"ref": "PV", "val": 50}], "tagsClasse": ["cleric"], "tier": 3, "set": { "id": "cleric_devotion_set", "name": "Habits du Dévoué" } },
       { "id": "set_cleric_t3_boots", "baseId": "set_cleric_t3_boots", "name": "Bottes du Dévoué Exalté", "slot": "feet", "niveauMin": 39, "rarity": "Légendaire", "affixes": [{"ref": "Armure", "val": 80}, {"ref": "Esprit", "val": 20}, {"ref": "PV", "val": 40}], "tagsClasse": ["cleric"], "tier": 3, "set": { "id": "cleric_devotion_set", "name": "Habits du Dévoué" } },
-      { "id": "set_cleric_t3_mace", "baseId": "set_cleric_t3_mace", "name": "Masse du Dévoué Exalté", "slot": "weapon", "niveauMin": 42, "rarity": "Légendaire", "affixes": [{"ref": "AttMin", "val": 45}, {"ref": "AttMax", "val": 60}, {"ref": "Esprit", "val": 45}, {"ref": "Intelligence", "val": 20}], "tagsClasse": ["cleric"], "tier": 3, "set": { "id": "cleric_devotion_set", "name": "Habits du Dévoué" } }
+      { "id": "set_cleric_t3_mace", "baseId": "set_cleric_t3_mace", "name": "Masse du Dévoué Exalté", "slot": "weapon", "niveauMin": 42, "rarity": "Légendaire", "affixes": [{"ref": "AttMin", "val": 45}, {"ref": "AttMax", "val": 60}, {"ref": "Esprit", "val": 45}, {"ref": "Intelligence", "val": 20}], "tagsClasse": ["cleric"], "tier": 3, "set": { "id": "cleric_devotion_set", "name": "Habits du Dévoué" } },
+      {
+        "id": "parrying_dagger",
+        "name": "Dague de parade",
+        "gender": "f",
+        "slot": "offhand",
+        "material_type": "metal",
+        "tags": ["weapon", "dagger", "metal", "offhand"],
+        "niveauMin": 5,
+        "rarity": "Commun",
+        "affixes": [
+            { "ref": "Esquive", "val": 1 }
+        ],
+        "tagsClasse": ["rogue"],
+        "vendorPrice": 25
+      },
+      {
+        "id": "main_gauche",
+        "name": "Main-gauche",
+        "gender": "f",
+        "slot": "offhand",
+        "material_type": "metal",
+        "tags": ["weapon", "sword", "metal", "offhand"],
+        "niveauMin": 15,
+        "rarity": "Magique",
+        "affixes": [
+            { "ref": "AttMin", "val": 5 },
+            { "ref": "AttMax", "val": 8 },
+            { "ref": "Dexterite", "val": 2 }
+        ],
+        "tagsClasse": ["rogue"],
+        "vendorPrice": 75
+      }
   ]
 }

--- a/src/core/formulas.ts
+++ b/src/core/formulas.ts
@@ -5,17 +5,20 @@ export const getModifiedStats = (baseStats: Stats, buffs: (Buff | Debuff)[], for
 
     buffs.forEach(buff => {
         if (buff.statMods) {
+            const stacks = buff.stacks || 1;
             buff.statMods.forEach(mod => {
                 const statKey = mod.stat as keyof Stats;
                 const statValue = modifiedStats[statKey];
 
                 if (typeof statValue === 'number' && typeof mod.value === 'number') {
                     if (mod.modifier === 'additive') {
-                        (modifiedStats[statKey] as number) += mod.value;
+                        (modifiedStats[statKey] as number) += mod.value * stacks;
                     } else if (mod.modifier === 'multiplicative') {
-                        (modifiedStats[statKey] as number) *= mod.value;
+                        if (mod.value !== 1) {
+                            (modifiedStats[statKey] as number) *= (1 + ((mod.value - 1) * stacks));
+                        }
                     } else if (mod.modifier === 'multiplicative_add') {
-                        (modifiedStats[statKey] as number) *= (1 + mod.value);
+                        (modifiedStats[statKey] as number) *= (1 + (mod.value * stacks));
                     }
                 }
             });

--- a/src/features/inventory/EquipmentView.tsx
+++ b/src/features/inventory/EquipmentView.tsx
@@ -21,7 +21,7 @@ function EquipmentSlot({ slotName, item }: { slotName: string; item: Item | null
             </div>
              <div className="w-1/4 text-right">
                 {item && (
-                     <Button size="sm" variant="ghost" onClick={() => unequipItem(item.slot as any)}>
+                     <Button size="sm" variant="ghost" onClick={() => unequipItem(slotName as any)}>
                         <BaggageClaim className="h-4 w-4" />
                      </Button>
                 )}

--- a/src/state/gameStore.ts
+++ b/src/state/gameStore.ts
@@ -8,7 +8,7 @@ import { getModifiedStats, getRankValue } from '@/core/formulas';
 import { generateProceduralItem } from '@/core/itemGenerator';
 import { v4 as uuidv4 } from 'uuid';
 import { AFFIX_TO_THEME } from '@/lib/constants';
-import { processSkill } from '@/core/skillProcessor';
+import { processSkill, applyPoisonProc } from '@/core/skillProcessor';
 
 export interface ActiveQuete {
   quete: Quete;
@@ -1954,19 +1954,7 @@ export const useGameStore = create<GameState>()(
                 });
             }
 
-            if (player.activeBuffs.some(b => b.id === 'deadly_poison_buff') && Math.random() < 0.3) {
-                const poisonDebuffId = 'deadly_poison_debuff';
-                let existingDebuff = target.activeDebuffs.find(d => d.id === poisonDebuffId);
-                if (existingDebuff) {
-                    existingDebuff.stacks = Math.min(5, (existingDebuff.stacks || 1) + 1);
-                    existingDebuff.duration = 12000;
-                } else {
-                    target.activeDebuffs.push({ id: poisonDebuffId, name: 'Poison mortel', duration: 12000, stacks: 1, isDebuff: true });
-                }
-                const stackCount = existingDebuff ? (existingDebuff.stacks || 1) : 1;
-                events.push({ entityId: target.id, text: `Poison (x${stackCount})`, type: 'debuff' });
-                combat.log.push({ message: `${target.nom} est affligé par le Poison mortel (x${stackCount}).`, type: 'poison_proc', timestamp: Date.now() });
-            }
+            applyPoisonProc(state, target, events);
 
             const attackMsg = `You hit ${target.nom} for ${mitigatedDamage} damage.`;
             const critMsg = `CRITICAL! You hit ${target.nom} for ${mitigatedDamage} damage.`;


### PR DESCRIPTION
… correctif pour la génération de butin et un correctif pour un bug de l'interface utilisateur de l'inventaire.

Changements de la compétence "Poison mortel" du voleur :
- L'amélioration de poison ne se cumule plus. Appliquer la compétence lorsque l'amélioration est active rafraîchit maintenant sa durée.
- Lorsque l'amélioration de poison est active, l'utilisation de la compétence déclenche désormais une attaque de zone sur tous les ennemis empoisonnés, infligeant des dégâts de nature et appliquant un affaiblissement de ralentissement cumulable.
- Le poison peut maintenant être appliqué par toutes les compétences infligeant des dégâts, et non plus seulement par les attaques de base.

Corrections de bugs :
- Ajout de nouveaux objets de main gauche pour les voleurs à la table de butin pour résoudre un problème où ils n'apparaissaient pas.
- Correction d'un bug où le déséquipement du deuxième anneau déséquipait le premier.

Améliorations du code :
- Réorganisation de la logique de traitement des compétences pour la rendre plus propre et plus facile à maintenir.
- Amélioration du système d'améliorations/affaiblissements pour gérer correctement les effets cumulables.