### PR TITLE
feat(skills): Make poison application guaranteed on skills

### DIFF
--- a/src/core/skillProcessor.ts
+++ b/src/core/skillProcessor.ts
@@ -9,9 +9,11 @@ import { SkillEffectSchema } from '@/data/schemas';
 export const applyPoisonProc = (
     state: WritableDraft<GameState>,
     target: WritableDraft<GameState>['combat']['enemies'][number],
-    floatingTexts: { entityId: string, text: string, type: FloatingTextType }[]
+    floatingTexts: { entityId: string, text: string, type: FloatingTextType }[],
+    forceApply = false
 ) => {
-    if (state.player.activeBuffs.some(b => b.id === 'deadly_poison_buff') && Math.random() < 0.3) {
+    const chance = forceApply ? 1 : 0.3;
+    if (state.player.activeBuffs.some(b => b.id === 'deadly_poison_buff') && Math.random() < chance) {
         const poisonDebuffId = 'deadly_poison_debuff';
         let existingPoison = target.activeDebuffs.find(d => d.id === poisonDebuffId);
 
@@ -113,7 +115,7 @@ export const processSkill = (
         if (isCrit) applySpecialEffect('ON_CRITICAL_HIT', { targetId: target.id, isCrit, skill: skill });
         applySpecialEffect('ON_HIT', { targetId: target.id, isCrit, skill: skill });
         if (!preventPoisonProc) {
-            applyPoisonProc(state, target, floatingTexts);
+            applyPoisonProc(state, target, floatingTexts, true);
         }
 
         let finalDamage = isCrit ? damage * (buffedPlayerStats.CritDmg / 100) : damage;


### PR DESCRIPTION
This commit refactors the rogue's poison mechanics based on user feedback to make poison application guaranteed on skill use.

- The `applyPoisonProc` function now accepts a `forceApply` parameter to distinguish between skill-based applications (100% chance) and auto-attack applications (30% chance).
- The `handleDamage` function, which is called by skills, now calls `applyPoisonProc` with `forceApply: true`.
- The call in `playerAttack` remains unchanged, preserving the 30% chance for auto-attacks.

This change also includes the fix for the `hasArchonBuff` `ReferenceError` and the refactoring of the slow mechanic into `applyPoisonProc` from the previous iteration.