### PR TITLE
Refactor AlertDialog usage to fix hydration errors

### DIFF
--- a/src/features/dungeons/DungeonsView.tsx
+++ b/src/features/dungeons/DungeonsView.tsx
@@ -166,15 +166,15 @@ export function DungeonsView() {
                 <AlertDialogContent>
                     <AlertDialogHeader>
                         <AlertDialogTitle>Quêtes Disponibles!</AlertDialogTitle>
-                        <AlertDialogDescription asChild>
-                            <div>
-                                <p className="mb-4">Les quêtes suivantes sont disponibles pour ce donjon. Voulez-vous toutes les accepter avant d&apos;entrer ?</p>
-                                <ul className="list-disc pl-5 space-y-1">
-                                    {proposedQuests?.map(q => <li key={q.id}>{q.name}</li>)}
-                                </ul>
-                            </div>
+                        <AlertDialogDescription>
+                            Les quêtes suivantes sont disponibles pour ce donjon. Voulez-vous toutes les accepter avant d&apos;entrer ?
                         </AlertDialogDescription>
                     </AlertDialogHeader>
+                    <div className="py-4">
+                        <ul className="list-disc pl-5 space-y-1">
+                            {proposedQuests?.map(q => <li key={q.id}>{q.name}</li>)}
+                        </ul>
+                    </div>
                     <AlertDialogFooter>
                         <AlertDialogCancel onClick={() => setProposedQuests(null)}>Annuler</AlertDialogCancel>
                         <AlertDialogAction onClick={handleDeclineQuestAndEnter}>Entrer sans accepter</AlertDialogAction>

--- a/src/features/town/ArtisanatForgeView.tsx
+++ b/src/features/town/ArtisanatForgeView.tsx
@@ -290,20 +290,21 @@ export const ArtisanatForgeView: React.FC = () => {
                     <AlertDialogHeader>
                         <AlertDialogTitle>Équiper l&apos;objet fabriqué ?</AlertDialogTitle>
                         <AlertDialogDescription>
-                            <div className={cn("grid gap-4 mt-4", equippedItemForPrompt ? "grid-cols-2" : "grid-cols-1")}>
-                                <div>
-                                    <h4 className="font-bold text-lg">Nouvel objet</h4>
-                                    <ItemTooltip item={showEquipPrompt} />
-                                </div>
-                                {equippedItemForPrompt && (
-                                     <div>
-                                        <h4 className="font-bold text-lg">Objet équipé</h4>
-                                        <ItemTooltip item={equippedItemForPrompt} />
-                                     </div>
-                                )}
-                            </div>
+                            Choisissez quoi faire avec l’objet nouvellement fabriqué.
                         </AlertDialogDescription>
                     </AlertDialogHeader>
+                    <div className={cn("grid gap-4 py-4", equippedItemForPrompt ? "grid-cols-2" : "grid-cols-1")}>
+                        <div>
+                            <h4 className="font-bold text-lg">Nouvel objet</h4>
+                            <ItemTooltip item={showEquipPrompt} />
+                        </div>
+                        {equippedItemForPrompt && (
+                                <div>
+                                <h4 className="font-bold text-lg">Objet équipé</h4>
+                                <ItemTooltip item={equippedItemForPrompt} />
+                                </div>
+                        )}
+                    </div>
                     <AlertDialogFooter>
                         <AlertDialogCancel onClick={() => setShowEquipPrompt(null)}>Garder</AlertDialogCancel>
                         <AlertDialogAction onClick={() => {


### PR DESCRIPTION
The `AlertDialogDescription` component from Radix UI renders a `<p>` element. Placing block-level elements like `<div>` or `<h4>` inside it results in invalid HTML and causes hydration errors in Next.js.

This commit refactors the `AlertDialog` components in `ArtisanatForgeView.tsx` and `DungeonsView.tsx` to move complex layouts and block-level elements out of `AlertDialogDescription`. The description is now reserved for simple text, as intended, which resolves the hydration warnings.