### PR TITLE
feat: Add background images to dungeon cards and boss alerts

### DIFF
--- a/src/features/combat/CombatView.tsx
+++ b/src/features/combat/CombatView.tsx
@@ -147,18 +147,28 @@ export function CombatView() {
 
       {/* AMÉLIORATION: Boîte de dialogue pour l'apparition du boss */}
       <AlertDialog open={!!bossEncounter} onOpenChange={() => setBossEncounter(null)}>
-        <AlertDialogContent>
+        <AlertDialogContent
+          className="bg-transparent text-white border-yellow-500"
+          style={{
+            backgroundImage: `url('/images/boss_biome${parseInt(currentDungeon.id.split('_')[1])}.png')`,
+            backgroundSize: 'cover',
+            backgroundPosition: 'center',
+          }}
+        >
+          <div className="absolute inset-0 bg-black/60 z-0" />
+          <div className="relative z-10">
             <AlertDialogHeader>
-                <AlertDialogTitle className="text-destructive text-2xl">
+                <AlertDialogTitle className="text-destructive text-4xl font-display text-center drop-shadow-[0_2px_2px_rgba(0,0,0,0.8)]">
                     {bossEncounter?.nom} apparaît !
                 </AlertDialogTitle>
-                <AlertDialogDescription>
+                <AlertDialogDescription className="text-center text-gray-300">
                     Préparez-vous au combat ! Le gardien de ce donjon est là.
                 </AlertDialogDescription>
             </AlertDialogHeader>
-            <AlertDialogFooter>
-                <AlertDialogAction onClick={() => setBossEncounter(null)}>Combattre !</AlertDialogAction>
+            <AlertDialogFooter className="mt-4">
+                <AlertDialogAction className="w-full" onClick={() => setBossEncounter(null)}>Combattre !</AlertDialogAction>
             </AlertDialogFooter>
+          </div>
         </AlertDialogContent>
       </AlertDialog>
     </div>

--- a/src/features/dungeons/DungeonsView.tsx
+++ b/src/features/dungeons/DungeonsView.tsx
@@ -130,33 +130,47 @@ export function DungeonsView() {
                             const activeQuestsForDungeon = activeQuests.filter(q => q.quete.requirements.dungeonId === dungeonToDisplay.id).length;
 
 
+                            const dungeonIndex = parseInt(dungeon.id.split('_')[1]);
+                            const cardStyle = {
+                                backgroundImage: `url('/images/biome${dungeonIndex}.png')`,
+                                backgroundSize: 'cover',
+                                backgroundPosition: 'center',
+                            };
+
                             return (
-                                <Card key={dungeon.id} className={`transition-all ${!isUnlocked ? 'bg-background/40 filter grayscale' : ''}`}>
-                                    <CardHeader>
-                                        <CardTitle className="flex justify-between items-center">
-                                            {dungeonToDisplay.name}
-                                            {activeQuestsForDungeon > 0 && (
-                                                <span className="text-xs bg-primary text-primary-foreground rounded-full px-2 py-0.5">
-                                                    {activeQuestsForDungeon} quête(s)
-                                                </span>
-                                            )}
-                                        </CardTitle>
-                                        <CardDescription>
-                                            Palier: {dungeonToDisplay.palier}
-                                            {isCompleted && <span className="text-primary font-bold ml-2"> (Terminé {completionCount}x)</span>}
-                                        </CardDescription>
-                                    </CardHeader>
-                                    <CardContent>
-                                        <p>Biome: <span className="capitalize text-primary">{dungeonToDisplay.biome}</span></p>
-                                        <p>Objectif: Tuer {dungeonToDisplay.killTarget} monstres.</p>
-                                    </CardContent>
-                                    <CardFooter>
-                                        <Button onClick={() => handleEnterDungeon(dungeon)} disabled={!isUnlocked}>
-                                            {isCompleted ? "Rejouer" : "Entrer"}
-                                        </Button>
-                                    </CardFooter>
+                                <Card
+                                    key={dungeon.id}
+                                    className={`transition-all relative overflow-hidden bg-transparent text-white ${!isUnlocked ? 'filter grayscale' : ''}`}
+                                    style={cardStyle}
+                                >
+                                    <div className="absolute inset-0 bg-black/50 z-0" />
+                                    <div className="relative z-10 flex flex-col h-full">
+                                        <CardHeader>
+                                            <CardTitle className="flex justify-between items-center">
+                                                {dungeonToDisplay.name}
+                                                {activeQuestsForDungeon > 0 && (
+                                                    <span className="text-xs bg-primary text-primary-foreground rounded-full px-2 py-0.5">
+                                                        {activeQuestsForDungeon} quête(s)
+                                                    </span>
+                                                )}
+                                            </CardTitle>
+                                            <CardDescription className="text-gray-300">
+                                                Palier: {dungeonToDisplay.palier}
+                                                {isCompleted && <span className="text-primary font-bold ml-2"> (Terminé {completionCount}x)</span>}
+                                            </CardDescription>
+                                        </CardHeader>
+                                        <CardContent className="flex-grow">
+                                            <p>Biome: <span className="capitalize text-primary">{dungeonToDisplay.biome}</span></p>
+                                            <p>Objectif: Tuer {dungeonToDisplay.killTarget} monstres.</p>
+                                        </CardContent>
+                                        <CardFooter>
+                                            <Button onClick={() => handleEnterDungeon(dungeon)} disabled={!isUnlocked}>
+                                                {isCompleted ? "Rejouer" : "Entrer"}
+                                            </Button>
+                                        </CardFooter>
+                                    </div>
                                 </Card>
-                            )
+                            );
                         })}
                     </div>
                 </div>

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -92,6 +92,8 @@ export interface Debuff {
     duration: number;
     isDebuff?: boolean;
     stacks?: number;
+    is_stacking?: boolean;
+    max_stacks?: number;
     damagePerTick?: number;
     tickInterval?: number;
     nextTickIn?: number;


### PR DESCRIPTION
This commit introduces background images for dungeon cards and boss encounter alerts to enhance the visual experience, following the user's specified naming convention.

- Dungeon cards now display a background image corresponding to their index (e.g., `biome1.png`, `biome2.png`). A dark overlay is added to ensure the text remains readable.
- The boss encounter alert now features a background image of the boss for that dungeon index (e.g., `boss_biome1.png`), with updated styling for a more impactful presentation.

This implementation corrects a previous version that used the biome's name instead of the dungeon's index for the image files.

Additionally, this commit includes a minor fix for a pre-existing type error in `src/lib/types.ts` by adding optional `is_stacking` and `max_stacks` properties to the `Debuff` interface. This was necessary to pass the type check and ensure a stable codebase.