### PR TITLE
feat: Enhance boss encounters and card visuals

### DIFF
--- a/src/state/gameStore.ts
+++ b/src/state/gameStore.ts
@@ -1699,10 +1699,10 @@ export const useGameStore = create<GameState>()(
       },
 
       gameTick: (delta: number) => {
-          const { view, combat } = get();
+          const { view, combat, bossEncounter } = get();
 
-          if(view !== 'COMBAT' || !combat.enemies || combat.enemies.length === 0) {
-            if(gameLoop) clearInterval(gameLoop);
+          if(view !== 'COMBAT' || !combat.enemies || combat.enemies.length === 0 || bossEncounter) {
+            if(gameLoop && view !== 'COMBAT') clearInterval(gameLoop);
             return;
           }
 


### PR DESCRIPTION
This commit introduces several features to improve the user experience for dungeon crawling and boss fights.

- **Dungeon Card Backgrounds**: Dungeon cards in the selection screen now display a background image based on their index (e.g., `biome1.png`), with an overlay to ensure text readability.
- **Boss Card Backgrounds**: In combat, the boss's card now features a background image (`boss_biomeX.png`) for a more atmospheric fight.
- **Combat Pause on Boss Arrival**: The combat loop is now paused when the boss encounter dialog is displayed, and resumes when the dialog is closed. This gives the player time to prepare for the fight.
- **Boss Alert Background**: The boss encounter alert dialog now also displays the boss's background image.

A pre-existing type error in the project was also fixed by adding optional `is_stacking` and `max_stacks` properties to the `Debuff` interface in `src/lib/types.ts`. This was necessary for the type check to pass.