### PR TITLE
feat: Create unique bosses for each dungeon

### DIFF
--- a/public/data/dungeons.json
+++ b/public/data/dungeons.json
@@ -1,1368 +1,1856 @@
 {
-    "dungeons": [
-        {
-            "id": "dungeon_1",
-            "heroicVersionId": "dungeon_1_heroic",
-            "palier": 1,
-            "name": "Goblin Mines",
-            "biome": "shadow",
-            "damagePenetration": { "type": "shadow", "value": 10 },
-            "monsters": [
-                "goblin_scout",
-                "giant_rat"
-            ],
-            "killTarget": 10,
-            "bossId": "kobold_miner_supervisor"
-        },
-        {
-            "id": "dungeon_2",
-            "heroicVersionId": "dungeon_2_heroic",
-            "palier": 1,
-            "name": "Bat Cave",
-            "biome": "shadow",
-            "damagePenetration": { "type": "shadow", "value": 10 },
-            "monsters": [
-                "kobold_miner",
-                "cave_bat"
-            ],
-            "killTarget": 15,
-            "bossId": "bat_matriarch"
-        },
-        {
-            "id": "dungeon_3",
-            "heroicVersionId": "dungeon_3_heroic",
-            "palier": 2,
-            "name": "Icy Crevasse",
-            "biome": "ice",
-            "damagePenetration": { "type": "ice", "value": 15 },
-            "monsters": [
-                "frost_wolf",
-                "ice_sprite"
-            ],
-            "killTarget": 20,
-            "bossId": "yeti_chieftain",
-            "factionId": "silver_guardians"
-        },
-        {
-            "id": "dungeon_4",
-            "heroicVersionId": "dungeon_4_heroic",
-            "palier": 2,
-            "name": "Yeti Den",
-            "biome": "ice",
-            "damagePenetration": { "type": "ice", "value": 15 },
-            "monsters": [
-                "ice_sprite",
-                "yeti_toddler"
-            ],
-            "killTarget": 20,
-            "bossId": "yeti_chieftain",
-            "factionId": "silver_guardians"
-        },
-        {
-            "id": "dungeon_5",
-            "heroicVersionId": "dungeon_5_heroic",
-            "palier": 3,
-            "name": "Scorched Caverns",
-            "biome": "fire",
-            "damagePenetration": { "type": "fire", "value": 15 },
-            "monsters": [
-                "volcanic_imp",
-                "magma_salamander"
-            ],
-            "killTarget": 25,
-            "bossId": "inferno_elemental_lord",
-            "factionId": "magma_watchers"
-        },
-        {
-            "id": "dungeon_6",
-            "heroicVersionId": "dungeon_6_heroic",
-            "palier": 3,
-            "name": "Cinder Chambers",
-            "biome": "fire",
-            "damagePenetration": { "type": "fire", "value": 15 },
-            "monsters": [
-                "magma_salamander",
-                "cinder_elemental"
-            ],
-            "killTarget": 25,
-            "bossId": "inferno_elemental_lord",
-            "factionId": "magma_watchers"
-        },
-        {
-            "id": "dungeon_7",
-            "heroicVersionId": "dungeon_7_heroic",
-            "palier": 4,
-            "name": "Whispering Woods",
-            "biome": "nature",
-            "damagePenetration": { "type": "nature", "value": 15 },
-            "monsters": [
-                "cursed_sapling",
-                "thorn_boar"
-            ],
-            "killTarget": 30,
-            "bossId": "ancient_dryad_matriarch",
-            "factionId": "grove_keepers"
-        },
-        {
-            "id": "dungeon_8",
-            "heroicVersionId": "dungeon_8_heroic",
-            "palier": 4,
-            "name": "Dryad Grove",
-            "biome": "nature",
-            "damagePenetration": { "type": "nature", "value": 15 },
-            "monsters": [
-                "thorn_boar",
-                "wandering_dryad"
-            ],
-            "killTarget": 30,
-            "bossId": "ancient_dryad_matriarch",
-            "factionId": "grove_keepers"
-        },
-        {
-            "id": "dungeon_9",
-            "heroicVersionId": "dungeon_9_heroic",
-            "palier": 5,
-            "name": "Forgotten Crypt",
-            "biome": "shadow",
-            "damagePenetration": { "type": "shadow", "value": 15 },
-            "monsters": [
-                "ghoul",
-                "shadow_wisp",
-                "acolyte_of_the_void"
-            ],
-            "killTarget": 35,
-            "bossId": "void_cultist_leader",
-            "factionId": "void_scholars"
-        },
-        {
-            "id": "dungeon_10",
-            "heroicVersionId": "dungeon_10_heroic",
-            "palier": 5,
-            "name": "Void Worshippers' Lair",
-            "biome": "shadow",
-            "damagePenetration": { "type": "shadow", "value": 15 },
-            "monsters": [
-                "shadow_wisp",
-                "acolyte_of_the_void",
-                "cultist_initiate"
-            ],
-            "killTarget": 35,
-            "bossId": "void_priest",
-            "factionId": "void_scholars"
-        },
-        {
-            "id": "dungeon_11",
-            "heroicVersionId": "dungeon_11_heroic",
-            "palier": 6,
-            "name": "Glacial Depths",
-            "biome": "ice",
-            "damagePenetration": { "type": "ice", "value": 20 },
-            "monsters": [
-                "polar_bear",
-                "glacial_elemental",
-                "ice_wraith"
-            ],
-            "killTarget": 40,
-            "bossId": "icebound_warlord",
-            "factionId": "silver_guardians"
-        },
-        {
-            "id": "dungeon_12",
-            "heroicVersionId": "dungeon_12_heroic",
-            "palier": 6,
-            "name": "Frozen Berserkers' Hall",
-            "biome": "ice",
-            "damagePenetration": { "type": "ice", "value": 20 },
-            "monsters": [
-                "glacial_elemental",
-                "ice_wraith",
-                "frozen_berserker"
-            ],
-            "killTarget": 40,
-            "bossId": "icebound_warlord",
-            "factionId": "silver_guardians"
-        },
-        {
-            "id": "dungeon_13",
-            "heroicVersionId": "dungeon_13_heroic",
-            "palier": 7,
-            "name": "Volcanic Core",
-            "biome": "fire",
-            "damagePenetration": { "type": "fire", "value": 20 },
-            "monsters": [
-                "pyroclastic_golem",
-                "hell_hound",
-                "obsidian_gargoyle"
-            ],
-            "killTarget": 45,
-            "bossId": "fire_giant_champion",
-            "factionId": "magma_watchers"
-        },
-        {
-            "id": "dungeon_14",
-            "heroicVersionId": "dungeon_14_heroic",
-            "palier": 7,
-            "name": "Fire Giants' Outpost",
-            "biome": "fire",
-            "damagePenetration": { "type": "fire", "value": 20 },
-            "monsters": [
-                "hell_hound",
-                "obsidian_gargoyle",
-                "fire_giant_scout"
-            ],
-            "killTarget": 45,
-            "bossId": "fire_giant_champion",
-            "factionId": "magma_watchers"
-        },
-        {
-            "id": "dungeon_15",
-            "heroicVersionId": "dungeon_15_heroic",
-            "palier": 8,
-            "name": "Verdant Labyrinth",
-            "biome": "nature",
-            "damagePenetration": { "type": "nature", "value": 20 },
-            "monsters": [
-                "razorvine_creeper",
-                "ancient_treant",
-                "grove_sentinel"
-            ],
-            "killTarget": 50,
-            "bossId": "guardian_of_the_grove",
-            "factionId": "grove_keepers"
-        },
-        {
-            "id": "dungeon_16",
-            "heroicVersionId": "dungeon_16_heroic",
-            "palier": 8,
-            "name": "Sylvan Guardians' Domain",
-            "biome": "nature",
-            "damagePenetration": { "type": "nature", "value": 20 },
-            "monsters": [
-                "ancient_treant",
-                "grove_sentinel",
-                "sylvan_protector"
-            ],
-            "killTarget": 50,
-            "bossId": "guardian_of_the_grove",
-            "factionId": "grove_keepers"
-        },
-        {
-            "id": "dungeon_17",
-            "heroicVersionId": "dungeon_17_heroic",
-            "palier": 9,
-            "name": "Shadowy Necropolis",
-            "biome": "shadow",
-            "damagePenetration": { "type": "shadow", "value": 20 },
-            "monsters": [
-                "wraith",
-                "mind_flayer_spawn",
-                "void_terror",
-                "shambling_horror"
-            ],
-            "killTarget": 55,
-            "bossId": "spectral_overlord",
-            "factionId": "void_scholars"
-        },
-        {
-            "id": "dungeon_18",
-            "heroicVersionId": "dungeon_18_heroic",
-            "palier": 9,
-            "name": "Specters' Sanctuary",
-            "biome": "shadow",
-            "damagePenetration": { "type": "shadow", "value": 20 },
-            "monsters": [
-                "mind_flayer_spawn",
-                "void_terror",
-                "shambling_horror",
-                "specter"
-            ],
-            "killTarget": 55,
-            "bossId": "spectral_overlord",
-            "factionId": "void_scholars"
-        },
-        {
-            "id": "dungeon_19",
-            "heroicVersionId": "dungeon_19_heroic",
-            "palier": 10,
-            "name": "Frozen Wastes",
-            "biome": "ice",
-            "damagePenetration": { "type": "ice", "value": 20 },
-            "monsters": [
-                "frost_giant",
-                "rime-scaled_drake",
-                "mammoth_calf",
-                "wendigo_spawn"
-            ],
-            "killTarget": 60,
-            "bossId": "boreal_crusader",
-            "factionId": "silver_guardians"
-        },
-        {
-            "id": "dungeon_20",
-            "heroicVersionId": "dungeon_20_heroic",
-            "palier": 10,
-            "name": "Boreal Knights' Fortress",
-            "biome": "ice",
-            "damagePenetration": { "type": "ice", "value": 20 },
-            "monsters": [
-                "rime-scaled_drake",
-                "mammoth_calf",
-                "wendigo_spawn",
-                "boreal_knight"
-            ],
-            "killTarget": 60,
-            "bossId": "boreal_crusader",
-            "factionId": "silver_guardians"
-        },
-        {
-            "id": "dungeon_21",
-            "heroicVersionId": "dungeon_21_heroic",
-            "palier": 11,
-            "name": "Infernal Forge",
-            "biome": "fire",
-            "damagePenetration": { "type": "fire", "value": 25 },
-            "monsters": [
-                "infernal_juggernaut",
-                "magma_dragon_whelp",
-                "flame_hydra",
-                "brimstone_devil"
-            ],
-            "killTarget": 65,
-            "bossId": "ashwing_matriarch",
-            "factionId": "magma_watchers"
-        },
-        {
-            "id": "dungeon_22",
-            "heroicVersionId": "dungeon_22_heroic",
-            "palier": 11,
-            "name": "Ash Harpies' Nest",
-            "biome": "fire",
-            "damagePenetration": { "type": "fire", "value": 25 },
-            "monsters": [
-                "magma_dragon_whelp",
-                "flame_hydra",
-                "brimstone_devil",
-                "ash_harpy"
-            ],
-            "killTarget": 65,
-            "bossId": "ashwing_matriarch",
-            "factionId": "magma_watchers"
-        },
-        {
-            "id": "dungeon_23",
-            "heroicVersionId": "dungeon_23_heroic",
-            "palier": 12,
-            "name": "Emerald Nightmare",
-            "biome": "nature",
-            "damagePenetration": { "type": "nature", "value": 25 },
-            "monsters": [
-                "colossal_carnivorous_plant",
-                "verdant_wyrm",
-                "elf_ranger",
-                "satyr_trickster"
-            ],
-            "killTarget": 70,
-            "bossId": "colossus_of_the_grove",
-            "factionId": "grove_keepers"
-        },
-        {
-            "id": "dungeon_24",
-            "heroicVersionId": "dungeon_24_heroic",
-            "palier": 12,
-            "name": "Emerald Golems' Garden",
-            "biome": "nature",
-            "damagePenetration": { "type": "nature", "value": 25 },
-            "monsters": [
-                "verdant_wyrm",
-                "elf_ranger",
-                "satyr_trickster",
-                "emerald_golem"
-            ],
-            "killTarget": 70,
-            "bossId": "colossus_of_the_grove",
-            "factionId": "grove_keepers"
-        },
-        {
-            "id": "dungeon_25",
-            "heroicVersionId": "dungeon_25_heroic",
-            "palier": 13,
-            "name": "Cathedral of Eternal Night",
-            "biome": "shadow",
-            "damagePenetration": { "type": "shadow", "value": 25 },
-            "monsters": [
-                "dread_lich",
-                "elder_thing",
-                "void_reaver",
-                "bone_collector",
-                "soul_eater"
-            ],
-            "killTarget": 75,
-            "bossId": "ancient_tomb_protector",
-            "factionId": "void_scholars"
-        },
-        {
-            "id": "dungeon_26",
-            "heroicVersionId": "dungeon_26_heroic",
-            "palier": 13,
-            "name": "Tomb Guardians' Crypt",
-            "biome": "shadow",
-            "damagePenetration": { "type": "shadow", "value": 25 },
-            "monsters": [
-                "elder_thing",
-                "void_reaver",
-                "bone_collector",
-                "soul_eater",
-                "tomb_guardian"
-            ],
-            "killTarget": 75,
-            "bossId": "ancient_tomb_protector",
-            "factionId": "void_scholars"
-        },
-        {
-            "id": "dungeon_27",
-            "heroicVersionId": "dungeon_27_heroic",
-            "palier": 14,
-            "name": "Glacier's Peak",
-            "biome": "ice",
-            "damagePenetration": { "type": "ice", "value": 25 },
-            "monsters": [
-                "ice_titan",
-                "avalanche_spirit",
-                "yeti_patriarch",
-                "frost-forged_sentinel",
-                "seraphim_of_ice"
-            ],
-            "killTarget": 80,
-            "bossId": "ancient_frost_wyrm",
-            "factionId": "silver_guardians"
-        },
-        {
-            "id": "dungeon_28",
-            "heroicVersionId": "dungeon_28_heroic",
-            "palier": 14,
-            "name": "Frost Wyrm's Lair",
-            "biome": "ice",
-            "damagePenetration": { "type": "ice", "value": 25 },
-            "monsters": [
-                "avalanche_spirit",
-                "yeti_patriarch",
-                "frost-forged_sentinel",
-                "seraphim_of_ice",
-                "ancient_frost_wyrm"
-            ],
-            "killTarget": 80,
-            "bossId": "ancient_frost_wyrm",
-            "factionId": "silver_guardians"
-        },
-        {
-            "id": "dungeon_29",
-            "heroicVersionId": "dungeon_29_heroic",
-            "palier": 15,
-            "name": "Heart of the Volcano",
-            "biome": "fire",
-            "damagePenetration": { "type": "fire", "value": 25 },
-            "monsters": [
-                "balrog",
-                "phoenix",
-                "efreeti_sultan",
-                "volcanic_titan",
-                "charred_legionnaire"
-            ],
-            "killTarget": 85,
-            "bossId": "primeval_magma_dragon",
-            "factionId": "magma_watchers"
-        },
-        {
-            "id": "dungeon_30",
-            "heroicVersionId": "dungeon_30_heroic",
-            "palier": 15,
-            "name": "Magma Dragon's Roost",
-            "biome": "fire",
-            "damagePenetration": { "type": "fire", "value": 25 },
-            "monsters": [
-                "phoenix",
-                "efreeti_sultan",
-                "volcanic_titan",
-                "charred_legionnaire",
-                "primeval_magma_dragon"
-            ],
-            "killTarget": 85,
-            "bossId": "primeval_magma_dragon",
-            "factionId": "magma_watchers"
-        },
-        {
-            "id": "dungeon_31",
-            "heroicVersionId": "dungeon_31_heroic",
-            "palier": 16,
-            "name": "Throne of the Wilds",
-            "biome": "nature",
-            "damagePenetration": { "type": "nature", "value": 25 },
-            "monsters": [
-                "gaia_avatar",
-                "archdruid_of_the_fang",
-                "fenrir's_chosen",
-                "fae_king",
-                "living_world-tree"
-            ],
-            "killTarget": 90,
-            "bossId": "world_ash_treant",
-            "factionId": "grove_keepers"
-        },
-        {
-            "id": "dungeon_32",
-            "heroicVersionId": "dungeon_32_heroic",
-            "palier": 16,
-            "name": "World Ash Treant's Grove",
-            "biome": "nature",
-            "damagePenetration": { "type": "nature", "value": 25 },
-            "monsters": [
-                "archdruid_of_the_fang",
-                "fenrir's_chosen",
-                "fae_king",
-                "living_world-tree",
-                "world_ash_treant"
-            ],
-            "killTarget": 90,
-            "bossId": "world_ash_treant",
-            "factionId": "grove_keepers"
-        },
-        {
-            "id": "dungeon_33",
-            "heroicVersionId": "dungeon_33_heroic",
-            "palier": 17,
-            "name": "The Void-Corrupted Sanctum",
-            "biome": "shadow",
-            "damagePenetration": { "type": "shadow", "value": 25 },
-            "monsters": [
-                "archlich_of_nar'thalas",
-                "gibbering_mouther",
-                "void_leviathan",
-                "ethereal_devourer",
-                "shadow_titan",
-                "death_knight_champion"
-            ],
-            "killTarget": 95,
-            "bossId": "herald_of_cthulhu",
-            "factionId": "void_scholars"
-        },
-        {
-            "id": "dungeon_34",
-            "heroicVersionId": "dungeon_34_heroic",
-            "palier": 17,
-            "name": "Cthulhu's Herald's Antechamber",
-            "biome": "shadow",
-            "damagePenetration": { "type": "shadow", "value": 25 },
-            "monsters": [
-                "gibbering_mouther",
-                "void_leviathan",
-                "ethereal_devourer",
-                "shadow_titan",
-                "death_knight_champion",
-                "herald_of_cthulhu"
-            ],
-            "killTarget": 95,
-            "bossId": "herald_of_cthulhu",
-            "factionId": "void_scholars"
-        },
-        {
-            "id": "dungeon_35",
-            "heroicVersionId": "dungeon_35_heroic",
-            "palier": 18,
-            "name": "Permafrost Citadel",
-            "biome": "ice",
-            "damagePenetration": { "type": "ice", "value": 25 },
-            "monsters": [
-                "ancient_frost_wyrm",
-                "ice_titan",
-                "seraphim_of_ice"
-            ],
-            "killTarget": 100,
-            "bossId": "ancient_frost_wyrm",
-            "factionId": "silver_guardians"
-        },
-        {
-            "id": "dungeon_36",
-            "heroicVersionId": "dungeon_36_heroic",
-            "palier": 18,
-            "name": "Molten Pinnacle",
-            "biome": "fire",
-            "damagePenetration": { "type": "fire", "value": 25 },
-            "monsters": [
-                "primeval_magma_dragon",
-                "balrog",
-                "phoenix"
-            ],
-            "killTarget": 100,
-            "bossId": "primeval_magma_dragon",
-            "factionId": "magma_watchers"
-        },
-        {
-            "id": "dungeon_37",
-            "heroicVersionId": "dungeon_37_heroic",
-            "palier": 19,
-            "name": "Heart of the Forest",
-            "biome": "nature",
-            "damagePenetration": { "type": "nature", "value": 25 },
-            "monsters": [
-                "world_ash_treant",
-                "gaia_avatar",
-                "fae_king"
-            ],
-            "killTarget": 100,
-            "bossId": "world_ash_treant",
-            "factionId": "grove_keepers"
-        },
-        {
-            "id": "dungeon_38",
-            "heroicVersionId": "dungeon_38_heroic",
-            "palier": 19,
-            "name": "R'lyeh's Threshold",
-            "biome": "shadow",
-            "damagePenetration": { "type": "shadow", "value": 25 },
-            "monsters": [
-                "herald_of_cthulhu",
-                "void_leviathan",
-                "archlich_of_nar'thalas"
-            ],
-            "killTarget": 100,
-            "bossId": "herald_of_cthulhu",
-            "factionId": "void_scholars"
-        },
-        {
-            "id": "dungeon_39",
-            "heroicVersionId": "dungeon_39_heroic",
-            "palier": 20,
-            "name": "Frozen Throne",
-            "biome": "ice",
-            "damagePenetration": { "type": "ice", "value": 25 },
-            "monsters": [
-                "ancient_frost_wyrm",
-                "ice_titan",
-                "seraphim_of_ice",
-                "boreal_knight"
-            ],
-            "killTarget": 100,
-            "bossId": "ancient_frost_wyrm",
-            "factionId": "silver_guardians"
-        },
-        {
-            "id": "dungeon_40",
-            "heroicVersionId": "dungeon_40_heroic",
-            "palier": 20,
-            "name": "Inferno's Core",
-            "biome": "fire",
-            "damagePenetration": { "type": "fire", "value": 25 },
-            "monsters": [
-                "primeval_magma_dragon",
-                "balrog",
-                "phoenix",
-                "efreeti_sultan"
-            ],
-            "killTarget": 100,
-            "bossId": "primeval_magma_dragon",
-            "factionId": "magma_watchers"
-        },
-        {
-            "id": "dungeon_41",
-            "heroicVersionId": "dungeon_41_heroic",
-            "palier": 21,
-            "name": "Verdant Sanctuary",
-            "biome": "nature",
-            "damagePenetration": { "type": "nature", "value": 25 },
-            "monsters": [
-                "world_ash_treant",
-                "gaia_avatar",
-                "fae_king",
-                "archdruid_of_the_fang"
-            ],
-            "killTarget": 100,
-            "bossId": "world_ash_treant",
-            "factionId": "grove_keepers"
-        },
-        {
-            "id": "dungeon_42",
-            "heroicVersionId": "dungeon_42_heroic",
-            "palier": 21,
-            "name": "The Sunken City",
-            "biome": "shadow",
-            "damagePenetration": { "type": "shadow", "value": 25 },
-            "monsters": [
-                "herald_of_cthulhu",
-                "void_leviathan",
-                "archlich_of_nar'thalas",
-                "shadow_titan"
-            ],
-            "killTarget": 100,
-            "bossId": "herald_of_cthulhu",
-            "factionId": "void_scholars"
-        },
-        {
-            "id": "dungeon_43",
-            "heroicVersionId": "dungeon_43_heroic",
-            "palier": 22,
-            "name": "Icecrown Citadel",
-            "biome": "ice",
-            "damagePenetration": { "type": "ice", "value": 25 },
-            "monsters": [
-                "ancient_frost_wyrm",
-                "ice_titan",
-                "seraphim_of_ice",
-                "boreal_knight",
-                "yeti_patriarch"
-            ],
-            "killTarget": 100,
-            "bossId": "ancient_frost_wyrm",
-            "factionId": "silver_guardians"
-        },
-        {
-            "id": "dungeon_44",
-            "heroicVersionId": "dungeon_44_heroic",
-            "palier": 22,
-            "name": "Blackrock Mountain",
-            "biome": "fire",
-            "damagePenetration": { "type": "fire", "value": 25 },
-            "monsters": [
-                "primeval_magma_dragon",
-                "balrog",
-                "phoenix",
-                "efreeti_sultan",
-                "volcanic_titan"
-            ],
-            "killTarget": 100,
-            "bossId": "primeval_magma_dragon",
-            "factionId": "magma_watchers"
-        },
-        {
-            "id": "dungeon_45",
-            "heroicVersionId": "dungeon_45_heroic",
-            "palier": 23,
-            "name": "The Emerald Dream",
-            "biome": "nature",
-            "damagePenetration": { "type": "nature", "value": 25 },
-            "monsters": [
-                "world_ash_treant",
-                "gaia_avatar",
-                "fae_king",
-                "archdruid_of_the_fang",
-                "fenrir's_chosen"
-            ],
-            "killTarget": 100,
-            "bossId": "world_ash_treant",
-            "factionId": "grove_keepers"
-        },
-        {
-            "id": "dungeon_46",
-            "heroicVersionId": "dungeon_46_heroic",
-            "palier": 23,
-            "name": "Ny'alotha, the Waking City",
-            "biome": "shadow",
-            "damagePenetration": { "type": "shadow", "value": 25 },
-            "monsters": [
-                "herald_of_cthulhu",
-                "void_leviathan",
-                "archlich_of_nar'thalas",
-                "shadow_titan",
-                "death_knight_champion"
-            ],
-            "killTarget": 100,
-            "bossId": "herald_of_cthulhu",
-            "factionId": "void_scholars"
-        },
-        {
-            "id": "dungeon_47",
-            "heroicVersionId": "dungeon_47_heroic",
-            "palier": 24,
-            "name": "The Frozen Halls",
-            "biome": "ice",
-            "damagePenetration": { "type": "ice", "value": 25 },
-            "monsters": [
-                "ancient_frost_wyrm",
-                "ice_titan",
-                "seraphim_of_ice",
-                "boreal_knight",
-                "yeti_patriarch",
-                "frost-forged_sentinel"
-            ],
-            "killTarget": 100,
-            "bossId": "ancient_frost_wyrm",
-            "factionId": "silver_guardians"
-        },
-        {
-            "id": "dungeon_48",
-            "heroicVersionId": "dungeon_48_heroic",
-            "palier": 25,
-            "name": "The Molten Core",
-            "biome": "fire",
-            "damagePenetration": { "type": "fire", "value": 25 },
-            "monsters": [
-                "primeval_magma_dragon",
-                "balrog",
-                "phoenix",
-                "efreeti_sultan",
-                "volcanic_titan",
-                "charred_legionnaire"
-            ],
-            "killTarget": 100,
-            "bossId": "primeval_magma_dragon",
-            "factionId": "magma_watchers"
-        },
-        {
-            "id": "dungeon_1_heroic",
-            "palier": 11,
-            "name": "Goblin Mines Héroïque",
-            "biome": "shadow",
-            "damagePenetration": { "type": "shadow", "value": 25 },
-            "monsters": [
-                "goblin_scout_heroic",
-                "giant_rat_heroic"
-            ],
-            "killTarget": 20,
-            "bossId": "kobold_miner_supervisor_heroic"
-        },
-        {
-            "id": "dungeon_2_heroic",
-            "palier": 11,
-            "name": "Bat Cave Héroïque",
-            "biome": "shadow",
-            "damagePenetration": { "type": "shadow", "value": 25 },
-            "monsters": [
-                "kobold_miner_assistant_heroic",
-                "cave_bat_heroic"
-            ],
-            "killTarget": 30,
-            "bossId": "bat_matriarch_heroic"
-        },
-        {
-            "id": "dungeon_3_heroic",
-            "palier": 12,
-            "name": "Icy Crevasse Héroïque",
-            "biome": "ice",
-            "damagePenetration": { "type": "ice", "value": 25 },
-            "monsters": [
-                "frost_wolf_heroic",
-                "ice_sprite_heroic"
-            ],
-            "killTarget": 40,
-            "bossId": "yeti_chieftain_heroic",
-            "factionId": "silver_guardians"
-        },
-        {
-            "id": "dungeon_4_heroic",
-            "palier": 12,
-            "name": "Yeti Den Héroïque",
-            "biome": "ice",
-            "damagePenetration": { "type": "ice", "value": 25 },
-            "monsters": [
-                "ice_sprite_heroic",
-                "yeti_toddler_heroic"
-            ],
-            "killTarget": 40,
-            "bossId": "yeti_chieftain_heroic",
-            "factionId": "silver_guardians"
-        },
-        {
-            "id": "dungeon_5_heroic",
-            "palier": 13,
-            "name": "Scorched Caverns Héroïque",
-            "biome": "fire",
-            "damagePenetration": { "type": "fire", "value": 25 },
-            "monsters": [
-                "volcanic_imp_heroic",
-                "magma_salamander_heroic"
-            ],
-            "killTarget": 50,
-            "bossId": "inferno_elemental_lord_heroic",
-            "factionId": "magma_watchers"
-        },
-        {
-            "id": "dungeon_6_heroic",
-            "palier": 13,
-            "name": "Cinder Chambers Héroïque",
-            "biome": "fire",
-            "damagePenetration": { "type": "fire", "value": 25 },
-            "monsters": [
-                "magma_salamander_heroic",
-                "cinder_elemental_heroic"
-            ],
-            "killTarget": 50,
-            "bossId": "inferno_elemental_lord_heroic",
-            "factionId": "magma_watchers"
-        },
-        {
-            "id": "dungeon_7_heroic",
-            "palier": 14,
-            "name": "Whispering Woods Héroïque",
-            "biome": "nature",
-            "damagePenetration": { "type": "nature", "value": 25 },
-            "monsters": [
-                "cursed_sapling_heroic",
-                "thorn_boar_heroic"
-            ],
-            "killTarget": 60,
-            "bossId": "ancient_dryad_matriarch_heroic",
-            "factionId": "grove_keepers"
-        },
-        {
-            "id": "dungeon_8_heroic",
-            "palier": 14,
-            "name": "Dryad Grove Héroïque",
-            "biome": "nature",
-            "damagePenetration": { "type": "nature", "value": 25 },
-            "monsters": [
-                "thorn_boar_heroic",
-                "wandering_dryad_heroic"
-            ],
-            "killTarget": 60,
-            "bossId": "ancient_dryad_matriarch_heroic",
-            "factionId": "grove_keepers"
-        },
-        {
-            "id": "dungeon_9_heroic",
-            "palier": 15,
-            "name": "Forgotten Crypt Héroïque",
-            "biome": "shadow",
-            "damagePenetration": { "type": "shadow", "value": 25 },
-            "monsters": [
-                "ghoul_heroic",
-                "shadow_wisp_heroic",
-                "acolyte_of_the_void_heroic"
-            ],
-            "killTarget": 70,
-            "bossId": "void_cultist_leader_heroic",
-            "factionId": "void_scholars"
-        },
-        {
-            "id": "dungeon_10_heroic",
-            "palier": 15,
-            "name": "Void Worshippers' Lair Héroïque",
-            "biome": "shadow",
-            "damagePenetration": { "type": "shadow", "value": 25 },
-            "monsters": [
-                "shadow_wisp_heroic",
-                "acolyte_of_the_void_heroic",
-                "cultist_initiate_heroic"
-            ],
-            "killTarget": 70,
-            "bossId": "void_priest_heroic",
-            "factionId": "void_scholars"
-        },
-        {
-            "id": "dungeon_11_heroic",
-            "palier": 16,
-            "name": "Glacial Depths Héroïque",
-            "biome": "ice",
-            "damagePenetration": { "type": "ice", "value": 25 },
-            "monsters": [ "polar_bear_heroic", "glacial_elemental_heroic", "ice_wraith_heroic" ],
-            "killTarget": 80,
-            "bossId": "icebound_warlord_heroic",
-            "factionId": "silver_guardians"
-        },
-        {
-            "id": "dungeon_12_heroic",
-            "palier": 16,
-            "name": "Frozen Berserkers' Hall Héroïque",
-            "biome": "ice",
-            "damagePenetration": { "type": "ice", "value": 25 },
-            "monsters": [ "glacial_elemental_heroic", "ice_wraith_heroic", "frozen_berserker_heroic" ],
-            "killTarget": 80,
-            "bossId": "icebound_warlord_heroic",
-            "factionId": "silver_guardians"
-        },
-        {
-            "id": "dungeon_13_heroic",
-            "palier": 17,
-            "name": "Volcanic Core Héroïque",
-            "biome": "fire",
-            "damagePenetration": { "type": "fire", "value": 25 },
-            "monsters": [ "pyroclastic_golem_heroic", "hell_hound_heroic", "obsidian_gargoyle_heroic" ],
-            "killTarget": 90,
-            "bossId": "fire_giant_champion_heroic",
-            "factionId": "magma_watchers"
-        },
-        {
-            "id": "dungeon_14_heroic",
-            "palier": 17,
-            "name": "Fire Giants' Outpost Héroïque",
-            "biome": "fire",
-            "damagePenetration": { "type": "fire", "value": 25 },
-            "monsters": [ "hell_hound_heroic", "obsidian_gargoyle_heroic", "fire_giant_scout_heroic" ],
-            "killTarget": 90,
-            "bossId": "fire_giant_champion_heroic",
-            "factionId": "magma_watchers"
-        },
-        {
-            "id": "dungeon_15_heroic",
-            "palier": 18,
-            "name": "Verdant Labyrinth Héroïque",
-            "biome": "nature",
-            "damagePenetration": { "type": "nature", "value": 25 },
-            "monsters": [ "razorvine_creeper_heroic", "ancient_treant_heroic", "grove_sentinel_heroic" ],
-            "killTarget": 100,
-            "bossId": "guardian_of_the_grove_heroic",
-            "factionId": "grove_keepers"
-        },
-        {
-            "id": "dungeon_16_heroic",
-            "palier": 18,
-            "name": "Sylvan Guardians' Domain Héroïque",
-            "biome": "nature",
-            "damagePenetration": { "type": "nature", "value": 25 },
-            "monsters": [ "ancient_treant_heroic", "grove_sentinel_heroic", "sylvan_protector_heroic" ],
-            "killTarget": 100,
-            "bossId": "guardian_of_the_grove_heroic",
-            "factionId": "grove_keepers"
-        },
-        {
-            "id": "dungeon_17_heroic",
-            "palier": 19,
-            "name": "Shadowy Necropolis Héroïque",
-            "biome": "shadow",
-            "damagePenetration": { "type": "shadow", "value": 25 },
-            "monsters": [ "wraith_heroic", "mind_flayer_spawn_heroic", "void_terror_heroic", "shambling_horror_heroic" ],
-            "killTarget": 110,
-            "bossId": "spectral_overlord_heroic",
-            "factionId": "void_scholars"
-        },
-        {
-            "id": "dungeon_18_heroic",
-            "palier": 19,
-            "name": "Specters' Sanctuary Héroïque",
-            "biome": "shadow",
-            "damagePenetration": { "type": "shadow", "value": 25 },
-            "monsters": [ "mind_flayer_spawn_heroic", "void_terror_heroic", "shambling_horror_heroic", "specter_heroic" ],
-            "killTarget": 110,
-            "bossId": "spectral_overlord_heroic",
-            "factionId": "void_scholars"
-        },
-        {
-            "id": "dungeon_19_heroic",
-            "palier": 20,
-            "name": "Frozen Wastes Héroïque",
-            "biome": "ice",
-            "damagePenetration": { "type": "ice", "value": 25 },
-            "monsters": [ "frost_giant_heroic", "rime-scaled_drake_heroic", "mammoth_calf_heroic", "wendigo_spawn_heroic" ],
-            "killTarget": 120,
-            "bossId": "boreal_crusader_heroic",
-            "factionId": "silver_guardians"
-        },
-        {
-            "id": "dungeon_20_heroic",
-            "palier": 20,
-            "name": "Boreal Knights' Fortress Héroïque",
-            "biome": "ice",
-            "damagePenetration": { "type": "ice", "value": 25 },
-            "monsters": [ "rime-scaled_drake_heroic", "mammoth_calf_heroic", "wendigo_spawn_heroic", "boreal_knight_heroic" ],
-            "killTarget": 120,
-            "bossId": "boreal_crusader_heroic",
-            "factionId": "silver_guardians"
-        },
-        {
-            "id": "dungeon_21_heroic",
-            "palier": 21,
-            "name": "Infernal Forge Héroïque",
-            "biome": "fire",
-            "damagePenetration": { "type": "fire", "value": 25 },
-            "monsters": [ "infernal_juggernaut_heroic", "magma_dragon_whelp_heroic", "flame_hydra_heroic", "brimstone_devil_heroic" ],
-            "killTarget": 130,
-            "bossId": "ashwing_matriarch_heroic",
-            "factionId": "magma_watchers"
-        },
-        {
-            "id": "dungeon_22_heroic",
-            "palier": 21,
-            "name": "Ash Harpies' Nest Héroïque",
-            "biome": "fire",
-            "damagePenetration": { "type": "fire", "value": 25 },
-            "monsters": [ "magma_dragon_whelp_heroic", "flame_hydra_heroic", "brimstone_devil_heroic", "ash_harpy_heroic" ],
-            "killTarget": 130,
-            "bossId": "ashwing_matriarch_heroic",
-            "factionId": "magma_watchers"
-        },
-        {
-            "id": "dungeon_23_heroic",
-            "palier": 22,
-            "name": "Emerald Nightmare Héroïque",
-            "biome": "nature",
-            "damagePenetration": { "type": "nature", "value": 25 },
-            "monsters": [ "colossal_carnivorous_plant_heroic", "verdant_wyrm_heroic", "elf_ranger_heroic", "satyr_trickster_heroic" ],
-            "killTarget": 140,
-            "bossId": "colossus_of_the_grove_heroic",
-            "factionId": "grove_keepers"
-        },
-        {
-            "id": "dungeon_24_heroic",
-            "palier": 22,
-            "name": "Emerald Golems' Garden Héroïque",
-            "biome": "nature",
-            "damagePenetration": { "type": "nature", "value": 25 },
-            "monsters": [ "verdant_wyrm_heroic", "elf_ranger_heroic", "satyr_trickster_heroic", "emerald_golem_heroic" ],
-            "killTarget": 140,
-            "bossId": "colossus_of_the_grove_heroic",
-            "factionId": "grove_keepers"
-        },
-        {
-            "id": "dungeon_25_heroic",
-            "palier": 23,
-            "name": "Cathedral of Eternal Night Héroïque",
-            "biome": "shadow",
-            "damagePenetration": { "type": "shadow", "value": 25 },
-            "monsters": [ "dread_lich_heroic", "elder_thing_heroic", "void_reaver_heroic", "bone_collector_heroic", "soul_eater_heroic" ],
-            "killTarget": 150,
-            "bossId": "ancient_tomb_protector_heroic",
-            "factionId": "void_scholars"
-        },
-        {
-            "id": "dungeon_26_heroic",
-            "palier": 23,
-            "name": "Tomb Guardians' Crypt Héroïque",
-            "biome": "shadow",
-            "damagePenetration": { "type": "shadow", "value": 25 },
-            "monsters": [ "elder_thing_heroic", "void_reaver_heroic", "bone_collector_heroic", "soul_eater_heroic", "tomb_guardian_heroic" ],
-            "killTarget": 150,
-            "bossId": "ancient_tomb_protector_heroic",
-            "factionId": "void_scholars"
-        },
-        {
-            "id": "dungeon_27_heroic",
-            "palier": 24,
-            "name": "Glacier's Peak Héroïque",
-            "biome": "ice",
-            "damagePenetration": { "type": "ice", "value": 25 },
-            "monsters": [ "ice_titan_heroic", "avalanche_spirit_heroic", "yeti_patriarch_heroic", "frost-forged_sentinel_heroic", "seraphim_of_ice_heroic" ],
-            "killTarget": 160,
-            "bossId": "ancient_frost_wyrm_heroic",
-            "factionId": "silver_guardians"
-        },
-        {
-            "id": "dungeon_28_heroic",
-            "palier": 24,
-            "name": "Frost Wyrm's Lair Héroïque",
-            "biome": "ice",
-            "damagePenetration": { "type": "ice", "value": 25 },
-            "monsters": [ "avalanche_spirit_heroic", "yeti_patriarch_heroic", "frost-forged_sentinel_heroic", "seraphim_of_ice_heroic", "ancient_frost_wyrm_heroic" ],
-            "killTarget": 160,
-            "bossId": "ancient_frost_wyrm_heroic",
-            "factionId": "silver_guardians"
-        },
-        {
-            "id": "dungeon_29_heroic",
-            "palier": 25,
-            "name": "Heart of the Volcano Héroïque",
-            "biome": "fire",
-            "damagePenetration": { "type": "fire", "value": 25 },
-            "monsters": [ "balrog_heroic", "phoenix_heroic", "efreeti_sultan_heroic", "volcanic_titan_heroic", "charred_legionnaire_heroic" ],
-            "killTarget": 170,
-            "bossId": "primeval_magma_dragon_heroic",
-            "factionId": "magma_watchers"
-        },
-        {
-            "id": "dungeon_30_heroic",
-            "palier": 25,
-            "name": "Magma Dragon's Roost Héroïque",
-            "biome": "fire",
-            "damagePenetration": { "type": "fire", "value": 25 },
-            "monsters": [ "phoenix_heroic", "efreeti_sultan_heroic", "volcanic_titan_heroic", "charred_legionnaire_heroic", "primeval_magma_dragon_heroic" ],
-            "killTarget": 170,
-            "bossId": "primeval_magma_dragon_heroic",
-            "factionId": "magma_watchers"
-        },
-        {
-            "id": "dungeon_31_heroic",
-            "palier": 26,
-            "name": "Throne of the Wilds Héroïque",
-            "biome": "nature",
-            "damagePenetration": { "type": "nature", "value": 25 },
-            "monsters": [ "gaia_avatar_heroic", "archdruid_of_the_fang_heroic", "fenrir's_chosen_heroic", "fae_king_heroic", "living_world-tree_heroic" ],
-            "killTarget": 180,
-            "bossId": "world_ash_treant_heroic",
-            "factionId": "grove_keepers"
-        },
-        {
-            "id": "dungeon_32_heroic",
-            "palier": 26,
-            "name": "World Ash Treant's Grove Héroïque",
-            "biome": "nature",
-            "damagePenetration": { "type": "nature", "value": 25 },
-            "monsters": [ "archdruid_of_the_fang_heroic", "fenrir's_chosen_heroic", "fae_king_heroic", "living_world-tree_heroic", "world_ash_treant_heroic" ],
-            "killTarget": 180,
-            "bossId": "world_ash_treant_heroic",
-            "factionId": "grove_keepers"
-        },
-        {
-            "id": "dungeon_33_heroic",
-            "palier": 27,
-            "name": "The Void-Corrupted Sanctum Héroïque",
-            "biome": "shadow",
-            "damagePenetration": { "type": "shadow", "value": 25 },
-            "monsters": [ "archlich_of_nar'thalas_heroic", "gibbering_mouther_heroic", "void_leviathan_heroic", "ethereal_devourer_heroic", "shadow_titan_heroic", "death_knight_champion_heroic" ],
-            "killTarget": 190,
-            "bossId": "herald_of_cthulhu_heroic",
-            "factionId": "void_scholars"
-        },
-        {
-            "id": "dungeon_34_heroic",
-            "palier": 27,
-            "name": "Cthulhu's Herald's Antechamber Héroïque",
-            "biome": "shadow",
-            "damagePenetration": { "type": "shadow", "value": 25 },
-            "monsters": [ "gibbering_mouther_heroic", "void_leviathan_heroic", "ethereal_devourer_heroic", "shadow_titan_heroic", "death_knight_champion_heroic", "herald_of_cthulhu_heroic" ],
-            "killTarget": 190,
-            "bossId": "herald_of_cthulhu_heroic",
-            "factionId": "void_scholars"
-        },
-        {
-            "id": "dungeon_35_heroic",
-            "palier": 28,
-            "name": "Permafrost Citadel Héroïque",
-            "biome": "ice",
-            "damagePenetration": { "type": "ice", "value": 25 },
-            "monsters": [ "ancient_frost_wyrm_heroic", "ice_titan_heroic", "seraphim_of_ice_heroic" ],
-            "killTarget": 200,
-            "bossId": "ancient_frost_wyrm_heroic",
-            "factionId": "silver_guardians"
-        },
-        {
-            "id": "dungeon_36_heroic",
-            "palier": 28,
-            "name": "Molten Pinnacle Héroïque",
-            "biome": "fire",
-            "damagePenetration": { "type": "fire", "value": 25 },
-            "monsters": [ "primeval_magma_dragon_heroic", "balrog_heroic", "phoenix_heroic" ],
-            "killTarget": 200,
-            "bossId": "primeval_magma_dragon_heroic",
-            "factionId": "magma_watchers"
-        },
-        {
-            "id": "dungeon_37_heroic",
-            "palier": 29,
-            "name": "Heart of the Forest Héroïque",
-            "biome": "nature",
-            "damagePenetration": { "type": "nature", "value": 25 },
-            "monsters": [ "world_ash_treant_heroic", "gaia_avatar_heroic", "fae_king_heroic" ],
-            "killTarget": 200,
-            "bossId": "world_ash_treant_heroic",
-            "factionId": "grove_keepers"
-        },
-        {
-            "id": "dungeon_38_heroic",
-            "palier": 29,
-            "name": "R'lyeh's Threshold Héroïque",
-            "biome": "shadow",
-            "damagePenetration": { "type": "shadow", "value": 25 },
-            "monsters": [ "herald_of_cthulhu_heroic", "void_leviathan_heroic", "archlich_of_nar'thalas_heroic" ],
-            "killTarget": 200,
-            "bossId": "herald_of_cthulhu_heroic",
-            "factionId": "void_scholars"
-        },
-        {
-            "id": "dungeon_39_heroic",
-            "palier": 30,
-            "name": "Frozen Throne Héroïque",
-            "biome": "ice",
-            "damagePenetration": { "type": "ice", "value": 25 },
-            "monsters": [ "ancient_frost_wyrm_heroic", "ice_titan_heroic", "seraphim_of_ice_heroic", "boreal_knight_heroic" ],
-            "killTarget": 200,
-            "bossId": "ancient_frost_wyrm_heroic",
-            "factionId": "silver_guardians"
-        },
-        {
-            "id": "dungeon_40_heroic",
-            "palier": 30,
-            "name": "Inferno's Core Héroïque",
-            "biome": "fire",
-            "damagePenetration": { "type": "fire", "value": 25 },
-            "monsters": [ "primeval_magma_dragon_heroic", "balrog_heroic", "phoenix_heroic", "efreeti_sultan_heroic" ],
-            "killTarget": 200,
-            "bossId": "primeval_magma_dragon_heroic",
-            "factionId": "magma_watchers"
-        },
-        {
-            "id": "dungeon_41_heroic",
-            "palier": 31,
-            "name": "Verdant Sanctuary Héroïque",
-            "biome": "nature",
-            "damagePenetration": { "type": "nature", "value": 25 },
-            "monsters": [ "world_ash_treant_heroic", "gaia_avatar_heroic", "fae_king_heroic", "archdruid_of_the_fang_heroic" ],
-            "killTarget": 200,
-            "bossId": "world_ash_treant_heroic",
-            "factionId": "grove_keepers"
-        },
-        {
-            "id": "dungeon_42_heroic",
-            "palier": 31,
-            "name": "The Sunken City Héroïque",
-            "biome": "shadow",
-            "damagePenetration": { "type": "shadow", "value": 25 },
-            "monsters": [ "herald_of_cthulhu_heroic", "void_leviathan_heroic", "archlich_of_nar'thalas_heroic", "shadow_titan_heroic" ],
-            "killTarget": 200,
-            "bossId": "herald_of_cthulhu_heroic",
-            "factionId": "void_scholars"
-        },
-        {
-            "id": "dungeon_43_heroic",
-            "palier": 32,
-            "name": "Icecrown Citadel Héroïque",
-            "biome": "ice",
-            "damagePenetration": { "type": "ice", "value": 25 },
-            "monsters": [ "ancient_frost_wyrm_heroic", "ice_titan_heroic", "seraphim_of_ice_heroic", "boreal_knight_heroic", "yeti_patriarch_heroic" ],
-            "killTarget": 200,
-            "bossId": "ancient_frost_wyrm_heroic",
-            "factionId": "silver_guardians"
-        },
-        {
-            "id": "dungeon_44_heroic",
-            "palier": 32,
-            "name": "Blackrock Mountain Héroïque",
-            "biome": "fire",
-            "damagePenetration": { "type": "fire", "value": 25 },
-            "monsters": [ "primeval_magma_dragon_heroic", "balrog_heroic", "phoenix_heroic", "efreeti_sultan_heroic", "volcanic_titan_heroic" ],
-            "killTarget": 200,
-            "bossId": "primeval_magma_dragon_heroic",
-            "factionId": "magma_watchers"
-        },
-        {
-            "id": "dungeon_45_heroic",
-            "palier": 33,
-            "name": "The Emerald Dream Héroïque",
-            "biome": "nature",
-            "damagePenetration": { "type": "nature", "value": 25 },
-            "monsters": [ "world_ash_treant_heroic", "gaia_avatar_heroic", "fae_king_heroic", "archdruid_of_the_fang_heroic", "fenrir's_chosen_heroic" ],
-            "killTarget": 200,
-            "bossId": "world_ash_treant_heroic",
-            "factionId": "grove_keepers"
-        },
-        {
-            "id": "dungeon_46_heroic",
-            "palier": 33,
-            "name": "Ny'alotha, the Waking City Héroïque",
-            "biome": "shadow",
-            "damagePenetration": { "type": "shadow", "value": 25 },
-            "monsters": [ "herald_of_cthulhu_heroic", "void_leviathan_heroic", "archlich_of_nar'thalas_heroic", "shadow_titan_heroic", "death_knight_champion_heroic" ],
-            "killTarget": 200,
-            "bossId": "herald_of_cthulhu_heroic",
-            "factionId": "void_scholars"
-        },
-        {
-            "id": "dungeon_47_heroic",
-            "palier": 34,
-            "name": "The Frozen Halls Héroïque",
-            "biome": "ice",
-            "damagePenetration": { "type": "ice", "value": 25 },
-            "monsters": [ "ancient_frost_wyrm_heroic", "ice_titan_heroic", "seraphim_of_ice_heroic", "boreal_knight_heroic", "yeti_patriarch_heroic", "frost-forged_sentinel_heroic" ],
-            "killTarget": 200,
-            "bossId": "ancient_frost_wyrm_heroic",
-            "factionId": "silver_guardians"
-        },
-        {
-            "id": "dungeon_48_heroic",
-            "palier": 35,
-            "name": "The Molten Core Héroïque",
-            "biome": "fire",
-            "damagePenetration": { "type": "fire", "value": 25 },
-            "monsters": [ "primeval_magma_dragon_heroic", "balrog_heroic", "phoenix_heroic", "efreeti_sultan_heroic", "volcanic_titan_heroic", "charred_legionnaire_heroic" ],
-            "killTarget": 200,
-            "bossId": "primeval_magma_dragon_heroic",
-            "factionId": "magma_watchers"
-        }
-    ]
+  "dungeons": [
+    {
+      "id": "dungeon_1",
+      "heroicVersionId": "dungeon_1_heroic",
+      "palier": 1,
+      "name": "Goblin Mines",
+      "biome": "shadow",
+      "damagePenetration": {
+        "type": "shadow",
+        "value": 10
+      },
+      "monsters": [
+        "goblin_scout",
+        "giant_rat"
+      ],
+      "killTarget": 10,
+      "bossId": "kobold_miner_supervisor"
+    },
+    {
+      "id": "dungeon_2",
+      "heroicVersionId": "dungeon_2_heroic",
+      "palier": 1,
+      "name": "Bat Cave",
+      "biome": "shadow",
+      "damagePenetration": {
+        "type": "shadow",
+        "value": 10
+      },
+      "monsters": [
+        "kobold_miner",
+        "cave_bat"
+      ],
+      "killTarget": 15,
+      "bossId": "bat_matriarch"
+    },
+    {
+      "id": "dungeon_3",
+      "heroicVersionId": "dungeon_3_heroic",
+      "palier": 2,
+      "name": "Icy Crevasse",
+      "biome": "ice",
+      "damagePenetration": {
+        "type": "ice",
+        "value": 15
+      },
+      "monsters": [
+        "frost_wolf",
+        "ice_sprite"
+      ],
+      "killTarget": 20,
+      "bossId": "yeti_chieftain",
+      "factionId": "silver_guardians"
+    },
+    {
+      "id": "dungeon_4",
+      "heroicVersionId": "dungeon_4_heroic",
+      "palier": 2,
+      "name": "Yeti Den",
+      "biome": "ice",
+      "damagePenetration": {
+        "type": "ice",
+        "value": 15
+      },
+      "monsters": [
+        "ice_sprite",
+        "yeti_toddler"
+      ],
+      "killTarget": 20,
+      "bossId": "yeti_matriarch",
+      "factionId": "silver_guardians"
+    },
+    {
+      "id": "dungeon_5",
+      "heroicVersionId": "dungeon_5_heroic",
+      "palier": 3,
+      "name": "Scorched Caverns",
+      "biome": "fire",
+      "damagePenetration": {
+        "type": "fire",
+        "value": 15
+      },
+      "monsters": [
+        "volcanic_imp",
+        "magma_salamander"
+      ],
+      "killTarget": 25,
+      "bossId": "inferno_elemental_lord",
+      "factionId": "magma_watchers"
+    },
+    {
+      "id": "dungeon_6",
+      "heroicVersionId": "dungeon_6_heroic",
+      "palier": 3,
+      "name": "Cinder Chambers",
+      "biome": "fire",
+      "damagePenetration": {
+        "type": "fire",
+        "value": 15
+      },
+      "monsters": [
+        "magma_salamander",
+        "cinder_elemental"
+      ],
+      "killTarget": 25,
+      "bossId": "cinder_lord",
+      "factionId": "magma_watchers"
+    },
+    {
+      "id": "dungeon_7",
+      "heroicVersionId": "dungeon_7_heroic",
+      "palier": 4,
+      "name": "Whispering Woods",
+      "biome": "nature",
+      "damagePenetration": {
+        "type": "nature",
+        "value": 15
+      },
+      "monsters": [
+        "cursed_sapling",
+        "thorn_boar"
+      ],
+      "killTarget": 30,
+      "bossId": "ancient_dryad_matriarch",
+      "factionId": "grove_keepers"
+    },
+    {
+      "id": "dungeon_8",
+      "heroicVersionId": "dungeon_8_heroic",
+      "palier": 4,
+      "name": "Dryad Grove",
+      "biome": "nature",
+      "damagePenetration": {
+        "type": "nature",
+        "value": 15
+      },
+      "monsters": [
+        "thorn_boar",
+        "wandering_dryad"
+      ],
+      "killTarget": 30,
+      "bossId": "grove_protector",
+      "factionId": "grove_keepers"
+    },
+    {
+      "id": "dungeon_9",
+      "heroicVersionId": "dungeon_9_heroic",
+      "palier": 5,
+      "name": "Forgotten Crypt",
+      "biome": "shadow",
+      "damagePenetration": {
+        "type": "shadow",
+        "value": 15
+      },
+      "monsters": [
+        "ghoul",
+        "shadow_wisp",
+        "acolyte_of_the_void"
+      ],
+      "killTarget": 35,
+      "bossId": "void_cultist_leader",
+      "factionId": "void_scholars"
+    },
+    {
+      "id": "dungeon_10",
+      "heroicVersionId": "dungeon_10_heroic",
+      "palier": 5,
+      "name": "Void Worshippers' Lair",
+      "biome": "shadow",
+      "damagePenetration": {
+        "type": "shadow",
+        "value": 15
+      },
+      "monsters": [
+        "shadow_wisp",
+        "acolyte_of_the_void",
+        "cultist_initiate"
+      ],
+      "killTarget": 35,
+      "bossId": "void_priest",
+      "factionId": "void_scholars"
+    },
+    {
+      "id": "dungeon_11",
+      "heroicVersionId": "dungeon_11_heroic",
+      "palier": 6,
+      "name": "Glacial Depths",
+      "biome": "ice",
+      "damagePenetration": {
+        "type": "ice",
+        "value": 20
+      },
+      "monsters": [
+        "polar_bear",
+        "glacial_elemental",
+        "ice_wraith"
+      ],
+      "killTarget": 40,
+      "bossId": "icebound_warlord",
+      "factionId": "silver_guardians"
+    },
+    {
+      "id": "dungeon_12",
+      "heroicVersionId": "dungeon_12_heroic",
+      "palier": 6,
+      "name": "Frozen Berserkers' Hall",
+      "biome": "ice",
+      "damagePenetration": {
+        "type": "ice",
+        "value": 20
+      },
+      "monsters": [
+        "glacial_elemental",
+        "ice_wraith",
+        "frozen_berserker"
+      ],
+      "killTarget": 40,
+      "bossId": "frozen_reaver",
+      "factionId": "silver_guardians"
+    },
+    {
+      "id": "dungeon_13",
+      "heroicVersionId": "dungeon_13_heroic",
+      "palier": 7,
+      "name": "Volcanic Core",
+      "biome": "fire",
+      "damagePenetration": {
+        "type": "fire",
+        "value": 20
+      },
+      "monsters": [
+        "pyroclastic_golem",
+        "hell_hound",
+        "obsidian_gargoyle"
+      ],
+      "killTarget": 45,
+      "bossId": "fire_giant_champion",
+      "factionId": "magma_watchers"
+    },
+    {
+      "id": "dungeon_14",
+      "heroicVersionId": "dungeon_14_heroic",
+      "palier": 7,
+      "name": "Fire Giants' Outpost",
+      "biome": "fire",
+      "damagePenetration": {
+        "type": "fire",
+        "value": 20
+      },
+      "monsters": [
+        "hell_hound",
+        "obsidian_gargoyle",
+        "fire_giant_scout"
+      ],
+      "killTarget": 45,
+      "bossId": "magma_destroyer",
+      "factionId": "magma_watchers"
+    },
+    {
+      "id": "dungeon_15",
+      "heroicVersionId": "dungeon_15_heroic",
+      "palier": 8,
+      "name": "Verdant Labyrinth",
+      "biome": "nature",
+      "damagePenetration": {
+        "type": "nature",
+        "value": 20
+      },
+      "monsters": [
+        "razorvine_creeper",
+        "ancient_treant",
+        "grove_sentinel"
+      ],
+      "killTarget": 50,
+      "bossId": "guardian_of_the_grove",
+      "factionId": "grove_keepers"
+    },
+    {
+      "id": "dungeon_16",
+      "heroicVersionId": "dungeon_16_heroic",
+      "palier": 8,
+      "name": "Sylvan Guardians' Domain",
+      "biome": "nature",
+      "damagePenetration": {
+        "type": "nature",
+        "value": 20
+      },
+      "monsters": [
+        "ancient_treant",
+        "grove_sentinel",
+        "sylvan_protector"
+      ],
+      "killTarget": 50,
+      "bossId": "sylvan_sentinel",
+      "factionId": "grove_keepers"
+    },
+    {
+      "id": "dungeon_17",
+      "heroicVersionId": "dungeon_17_heroic",
+      "palier": 9,
+      "name": "Shadowy Necropolis",
+      "biome": "shadow",
+      "damagePenetration": {
+        "type": "shadow",
+        "value": 20
+      },
+      "monsters": [
+        "wraith",
+        "mind_flayer_spawn",
+        "void_terror",
+        "shambling_horror"
+      ],
+      "killTarget": 55,
+      "bossId": "spectral_overlord",
+      "factionId": "void_scholars"
+    },
+    {
+      "id": "dungeon_18",
+      "heroicVersionId": "dungeon_18_heroic",
+      "palier": 9,
+      "name": "Specters' Sanctuary",
+      "biome": "shadow",
+      "damagePenetration": {
+        "type": "shadow",
+        "value": 20
+      },
+      "monsters": [
+        "mind_flayer_spawn",
+        "void_terror",
+        "shambling_horror",
+        "specter"
+      ],
+      "killTarget": 55,
+      "bossId": "nether_lich",
+      "factionId": "void_scholars"
+    },
+    {
+      "id": "dungeon_19",
+      "heroicVersionId": "dungeon_19_heroic",
+      "palier": 10,
+      "name": "Frozen Wastes",
+      "biome": "ice",
+      "damagePenetration": {
+        "type": "ice",
+        "value": 20
+      },
+      "monsters": [
+        "frost_giant",
+        "rime-scaled_drake",
+        "mammoth_calf",
+        "wendigo_spawn"
+      ],
+      "killTarget": 60,
+      "bossId": "boreal_crusader",
+      "factionId": "silver_guardians"
+    },
+    {
+      "id": "dungeon_20",
+      "heroicVersionId": "dungeon_20_heroic",
+      "palier": 10,
+      "name": "Boreal Knights' Fortress",
+      "biome": "ice",
+      "damagePenetration": {
+        "type": "ice",
+        "value": 20
+      },
+      "monsters": [
+        "rime-scaled_drake",
+        "mammoth_calf",
+        "wendigo_spawn",
+        "boreal_knight"
+      ],
+      "killTarget": 60,
+      "bossId": "tundra_king",
+      "factionId": "silver_guardians"
+    },
+    {
+      "id": "dungeon_21",
+      "heroicVersionId": "dungeon_21_heroic",
+      "palier": 11,
+      "name": "Infernal Forge",
+      "biome": "fire",
+      "damagePenetration": {
+        "type": "fire",
+        "value": 25
+      },
+      "monsters": [
+        "infernal_juggernaut",
+        "magma_dragon_whelp",
+        "flame_hydra",
+        "brimstone_devil"
+      ],
+      "killTarget": 65,
+      "bossId": "ashwing_matriarch",
+      "factionId": "magma_watchers"
+    },
+    {
+      "id": "dungeon_22",
+      "heroicVersionId": "dungeon_22_heroic",
+      "palier": 11,
+      "name": "Ash Harpies' Nest",
+      "biome": "fire",
+      "damagePenetration": {
+        "type": "fire",
+        "value": 25
+      },
+      "monsters": [
+        "magma_dragon_whelp",
+        "flame_hydra",
+        "brimstone_devil",
+        "ash_harpy"
+      ],
+      "killTarget": 65,
+      "bossId": "emberwing_scion",
+      "factionId": "magma_watchers"
+    },
+    {
+      "id": "dungeon_23",
+      "heroicVersionId": "dungeon_23_heroic",
+      "palier": 12,
+      "name": "Emerald Nightmare",
+      "biome": "nature",
+      "damagePenetration": {
+        "type": "nature",
+        "value": 25
+      },
+      "monsters": [
+        "colossal_carnivorous_plant",
+        "verdant_wyrm",
+        "elf_ranger",
+        "satyr_trickster"
+      ],
+      "killTarget": 70,
+      "bossId": "colossus_of_the_grove",
+      "factionId": "grove_keepers"
+    },
+    {
+      "id": "dungeon_24",
+      "heroicVersionId": "dungeon_24_heroic",
+      "palier": 12,
+      "name": "Emerald Golems' Garden",
+      "biome": "nature",
+      "damagePenetration": {
+        "type": "nature",
+        "value": 25
+      },
+      "monsters": [
+        "verdant_wyrm",
+        "elf_ranger",
+        "satyr_trickster",
+        "emerald_golem"
+      ],
+      "killTarget": 70,
+      "bossId": "emerald_titan",
+      "factionId": "grove_keepers"
+    },
+    {
+      "id": "dungeon_25",
+      "heroicVersionId": "dungeon_25_heroic",
+      "palier": 13,
+      "name": "Cathedral of Eternal Night",
+      "biome": "shadow",
+      "damagePenetration": {
+        "type": "shadow",
+        "value": 25
+      },
+      "monsters": [
+        "dread_lich",
+        "elder_thing",
+        "void_reaver",
+        "bone_collector",
+        "soul_eater"
+      ],
+      "killTarget": 75,
+      "bossId": "ancient_tomb_protector",
+      "factionId": "void_scholars"
+    },
+    {
+      "id": "dungeon_26",
+      "heroicVersionId": "dungeon_26_heroic",
+      "palier": 13,
+      "name": "Tomb Guardians' Crypt",
+      "biome": "shadow",
+      "damagePenetration": {
+        "type": "shadow",
+        "value": 25
+      },
+      "monsters": [
+        "elder_thing",
+        "void_reaver",
+        "bone_collector",
+        "soul_eater",
+        "tomb_guardian"
+      ],
+      "killTarget": 75,
+      "bossId": "crypt_lord",
+      "factionId": "void_scholars"
+    },
+    {
+      "id": "dungeon_27",
+      "heroicVersionId": "dungeon_27_heroic",
+      "palier": 14,
+      "name": "Glacier's Peak",
+      "biome": "ice",
+      "damagePenetration": {
+        "type": "ice",
+        "value": 25
+      },
+      "monsters": [
+        "ice_titan",
+        "avalanche_spirit",
+        "yeti_patriarch",
+        "frost-forged_sentinel",
+        "seraphim_of_ice"
+      ],
+      "killTarget": 80,
+      "bossId": "ancient_frost_wyrm",
+      "factionId": "silver_guardians"
+    },
+    {
+      "id": "dungeon_28",
+      "heroicVersionId": "dungeon_28_heroic",
+      "palier": 14,
+      "name": "Frost Wyrm's Lair",
+      "biome": "ice",
+      "damagePenetration": {
+        "type": "ice",
+        "value": 25
+      },
+      "monsters": [
+        "avalanche_spirit",
+        "yeti_patriarch",
+        "frost-forged_sentinel",
+        "seraphim_of_ice",
+        "ancient_frost_wyrm"
+      ],
+      "killTarget": 80,
+      "bossId": "glacial_behemoth",
+      "factionId": "silver_guardians"
+    },
+    {
+      "id": "dungeon_29",
+      "heroicVersionId": "dungeon_29_heroic",
+      "palier": 15,
+      "name": "Heart of the Volcano",
+      "biome": "fire",
+      "damagePenetration": {
+        "type": "fire",
+        "value": 25
+      },
+      "monsters": [
+        "balrog",
+        "phoenix",
+        "efreeti_sultan",
+        "volcanic_titan",
+        "charred_legionnaire"
+      ],
+      "killTarget": 85,
+      "bossId": "primeval_magma_dragon",
+      "factionId": "magma_watchers"
+    },
+    {
+      "id": "dungeon_30",
+      "heroicVersionId": "dungeon_30_heroic",
+      "palier": 15,
+      "name": "Magma Dragon's Roost",
+      "biome": "fire",
+      "damagePenetration": {
+        "type": "fire",
+        "value": 25
+      },
+      "monsters": [
+        "phoenix",
+        "efreeti_sultan",
+        "volcanic_titan",
+        "charred_legionnaire",
+        "primeval_magma_dragon"
+      ],
+      "killTarget": 85,
+      "bossId": "volcanic_annihilator",
+      "factionId": "magma_watchers"
+    },
+    {
+      "id": "dungeon_31",
+      "heroicVersionId": "dungeon_31_heroic",
+      "palier": 16,
+      "name": "Throne of the Wilds",
+      "biome": "nature",
+      "damagePenetration": {
+        "type": "nature",
+        "value": 25
+      },
+      "monsters": [
+        "gaia_avatar",
+        "archdruid_of_the_fang",
+        "fenrir's_chosen",
+        "fae_king",
+        "living_world-tree"
+      ],
+      "killTarget": 90,
+      "bossId": "world_ash_treant",
+      "factionId": "grove_keepers"
+    },
+    {
+      "id": "dungeon_32",
+      "heroicVersionId": "dungeon_32_heroic",
+      "palier": 16,
+      "name": "World Ash Treant's Grove",
+      "biome": "nature",
+      "damagePenetration": {
+        "type": "nature",
+        "value": 25
+      },
+      "monsters": [
+        "archdruid_of_the_fang",
+        "fenrir's_chosen",
+        "fae_king",
+        "living_world-tree",
+        "world_ash_treant"
+      ],
+      "killTarget": 90,
+      "bossId": "verdant_colossus",
+      "factionId": "grove_keepers"
+    },
+    {
+      "id": "dungeon_33",
+      "heroicVersionId": "dungeon_33_heroic",
+      "palier": 17,
+      "name": "The Void-Corrupted Sanctum",
+      "biome": "shadow",
+      "damagePenetration": {
+        "type": "shadow",
+        "value": 25
+      },
+      "monsters": [
+        "archlich_of_nar'thalas",
+        "gibbering_mouther",
+        "void_leviathan",
+        "ethereal_devourer",
+        "shadow_titan",
+        "death_knight_champion"
+      ],
+      "killTarget": 95,
+      "bossId": "herald_of_cthulhu",
+      "factionId": "void_scholars"
+    },
+    {
+      "id": "dungeon_34",
+      "heroicVersionId": "dungeon_34_heroic",
+      "palier": 17,
+      "name": "Cthulhu's Herald's Antechamber",
+      "biome": "shadow",
+      "damagePenetration": {
+        "type": "shadow",
+        "value": 25
+      },
+      "monsters": [
+        "gibbering_mouther",
+        "void_leviathan",
+        "ethereal_devourer",
+        "shadow_titan",
+        "death_knight_champion",
+        "herald_of_cthulhu"
+      ],
+      "killTarget": 95,
+      "bossId": "void_harbinger",
+      "factionId": "void_scholars"
+    },
+    {
+      "id": "dungeon_35",
+      "heroicVersionId": "dungeon_35_heroic",
+      "palier": 18,
+      "name": "Permafrost Citadel",
+      "biome": "ice",
+      "damagePenetration": {
+        "type": "ice",
+        "value": 25
+      },
+      "monsters": [
+        "ancient_frost_wyrm",
+        "ice_titan",
+        "seraphim_of_ice"
+      ],
+      "killTarget": 100,
+      "bossId": "icecrown_sentinel",
+      "factionId": "silver_guardians"
+    },
+    {
+      "id": "dungeon_36",
+      "heroicVersionId": "dungeon_36_heroic",
+      "palier": 18,
+      "name": "Molten Pinnacle",
+      "biome": "fire",
+      "damagePenetration": {
+        "type": "fire",
+        "value": 25
+      },
+      "monsters": [
+        "primeval_magma_dragon",
+        "balrog",
+        "phoenix"
+      ],
+      "killTarget": 100,
+      "bossId": "infernal_reaver",
+      "factionId": "magma_watchers"
+    },
+    {
+      "id": "dungeon_37",
+      "heroicVersionId": "dungeon_37_heroic",
+      "palier": 19,
+      "name": "Heart of the Forest",
+      "biome": "nature",
+      "damagePenetration": {
+        "type": "nature",
+        "value": 25
+      },
+      "monsters": [
+        "world_ash_treant",
+        "gaia_avatar",
+        "fae_king"
+      ],
+      "killTarget": 100,
+      "bossId": "emerald_dreamer",
+      "factionId": "grove_keepers"
+    },
+    {
+      "id": "dungeon_38",
+      "heroicVersionId": "dungeon_38_heroic",
+      "palier": 19,
+      "name": "R'lyeh's Threshold",
+      "biome": "shadow",
+      "damagePenetration": {
+        "type": "shadow",
+        "value": 25
+      },
+      "monsters": [
+        "herald_of_cthulhu",
+        "void_leviathan",
+        "archlich_of_nar'thalas"
+      ],
+      "killTarget": 100,
+      "bossId": "sunken_horror",
+      "factionId": "void_scholars"
+    },
+    {
+      "id": "dungeon_39",
+      "heroicVersionId": "dungeon_39_heroic",
+      "palier": 20,
+      "name": "Frozen Throne",
+      "biome": "ice",
+      "damagePenetration": {
+        "type": "ice",
+        "value": 25
+      },
+      "monsters": [
+        "ancient_frost_wyrm",
+        "ice_titan",
+        "seraphim_of_ice",
+        "boreal_knight"
+      ],
+      "killTarget": 100,
+      "bossId": "frostlord",
+      "factionId": "silver_guardians"
+    },
+    {
+      "id": "dungeon_40",
+      "heroicVersionId": "dungeon_40_heroic",
+      "palier": 20,
+      "name": "Inferno's Core",
+      "biome": "fire",
+      "damagePenetration": {
+        "type": "fire",
+        "value": 25
+      },
+      "monsters": [
+        "primeval_magma_dragon",
+        "balrog",
+        "phoenix",
+        "efreeti_sultan"
+      ],
+      "killTarget": 100,
+      "bossId": "blackrock_tyrant",
+      "factionId": "magma_watchers"
+    },
+    {
+      "id": "dungeon_41",
+      "heroicVersionId": "dungeon_41_heroic",
+      "palier": 21,
+      "name": "Verdant Sanctuary",
+      "biome": "nature",
+      "damagePenetration": {
+        "type": "nature",
+        "value": 25
+      },
+      "monsters": [
+        "world_ash_treant",
+        "gaia_avatar",
+        "fae_king",
+        "archdruid_of_the_fang"
+      ],
+      "killTarget": 100,
+      "bossId": "sylvan_goliath",
+      "factionId": "grove_keepers"
+    },
+    {
+      "id": "dungeon_42",
+      "heroicVersionId": "dungeon_42_heroic",
+      "palier": 21,
+      "name": "The Sunken City",
+      "biome": "shadow",
+      "damagePenetration": {
+        "type": "shadow",
+        "value": 25
+      },
+      "monsters": [
+        "herald_of_cthulhu",
+        "void_leviathan",
+        "archlich_of_nar'thalas",
+        "shadow_titan"
+      ],
+      "killTarget": 100,
+      "bossId": "nyalotha_prophet",
+      "factionId": "void_scholars"
+    },
+    {
+      "id": "dungeon_43",
+      "heroicVersionId": "dungeon_43_heroic",
+      "palier": 22,
+      "name": "Icecrown Citadel",
+      "biome": "ice",
+      "damagePenetration": {
+        "type": "ice",
+        "value": 25
+      },
+      "monsters": [
+        "ancient_frost_wyrm",
+        "ice_titan",
+        "seraphim_of_ice",
+        "boreal_knight",
+        "yeti_patriarch"
+      ],
+      "killTarget": 100,
+      "bossId": "rimefang",
+      "factionId": "silver_guardians"
+    },
+    {
+      "id": "dungeon_44",
+      "heroicVersionId": "dungeon_44_heroic",
+      "palier": 22,
+      "name": "Blackrock Mountain",
+      "biome": "fire",
+      "damagePenetration": {
+        "type": "fire",
+        "value": 25
+      },
+      "monsters": [
+        "primeval_magma_dragon",
+        "balrog",
+        "phoenix",
+        "efreeti_sultan",
+        "volcanic_titan"
+      ],
+      "killTarget": 100,
+      "bossId": "molten_leviathan",
+      "factionId": "magma_watchers"
+    },
+    {
+      "id": "dungeon_45",
+      "heroicVersionId": "dungeon_45_heroic",
+      "palier": 23,
+      "name": "The Emerald Dream",
+      "biome": "nature",
+      "damagePenetration": {
+        "type": "nature",
+        "value": 25
+      },
+      "monsters": [
+        "world_ash_treant",
+        "gaia_avatar",
+        "fae_king",
+        "archdruid_of_the_fang",
+        "fenrir's_chosen"
+      ],
+      "killTarget": 100,
+      "bossId": "heart_of_the_forest",
+      "factionId": "grove_keepers"
+    },
+    {
+      "id": "dungeon_46",
+      "heroicVersionId": "dungeon_46_heroic",
+      "palier": 23,
+      "name": "Ny'alotha, the Waking City",
+      "biome": "shadow",
+      "damagePenetration": {
+        "type": "shadow",
+        "value": 25
+      },
+      "monsters": [
+        "herald_of_cthulhu",
+        "void_leviathan",
+        "archlich_of_nar'thalas",
+        "shadow_titan",
+        "death_knight_champion"
+      ],
+      "killTarget": 100,
+      "bossId": "shadow_of_rlyeh",
+      "factionId": "void_scholars"
+    },
+    {
+      "id": "dungeon_47",
+      "heroicVersionId": "dungeon_47_heroic",
+      "palier": 24,
+      "name": "The Frozen Halls",
+      "biome": "ice",
+      "damagePenetration": {
+        "type": "ice",
+        "value": 25
+      },
+      "monsters": [
+        "ancient_frost_wyrm",
+        "ice_titan",
+        "seraphim_of_ice",
+        "boreal_knight",
+        "yeti_patriarch",
+        "frost-forged_sentinel"
+      ],
+      "killTarget": 100,
+      "bossId": "frozen_terror",
+      "factionId": "silver_guardians"
+    },
+    {
+      "id": "dungeon_48",
+      "heroicVersionId": "dungeon_48_heroic",
+      "palier": 25,
+      "name": "The Molten Core",
+      "biome": "fire",
+      "damagePenetration": {
+        "type": "fire",
+        "value": 25
+      },
+      "monsters": [
+        "primeval_magma_dragon",
+        "balrog",
+        "phoenix",
+        "efreeti_sultan",
+        "volcanic_titan",
+        "charred_legionnaire"
+      ],
+      "killTarget": 100,
+      "bossId": "blazing_juggernaut",
+      "factionId": "magma_watchers"
+    },
+    {
+      "id": "dungeon_1_heroic",
+      "palier": 11,
+      "name": "Goblin Mines Héroïque",
+      "biome": "shadow",
+      "damagePenetration": {
+        "type": "shadow",
+        "value": 25
+      },
+      "monsters": [
+        "goblin_scout_heroic",
+        "giant_rat_heroic"
+      ],
+      "killTarget": 20,
+      "bossId": "kobold_miner_supervisor_heroic"
+    },
+    {
+      "id": "dungeon_2_heroic",
+      "palier": 11,
+      "name": "Bat Cave Héroïque",
+      "biome": "shadow",
+      "damagePenetration": {
+        "type": "shadow",
+        "value": 25
+      },
+      "monsters": [
+        "kobold_miner_assistant_heroic",
+        "cave_bat_heroic"
+      ],
+      "killTarget": 30,
+      "bossId": "bat_matriarch_heroic"
+    },
+    {
+      "id": "dungeon_3_heroic",
+      "palier": 12,
+      "name": "Icy Crevasse Héroïque",
+      "biome": "ice",
+      "damagePenetration": {
+        "type": "ice",
+        "value": 25
+      },
+      "monsters": [
+        "frost_wolf_heroic",
+        "ice_sprite_heroic"
+      ],
+      "killTarget": 40,
+      "bossId": "yeti_chieftain_heroic",
+      "factionId": "silver_guardians"
+    },
+    {
+      "id": "dungeon_4_heroic",
+      "palier": 12,
+      "name": "Yeti Den Héroïque",
+      "biome": "ice",
+      "damagePenetration": {
+        "type": "ice",
+        "value": 25
+      },
+      "monsters": [
+        "ice_sprite_heroic",
+        "yeti_toddler_heroic"
+      ],
+      "killTarget": 40,
+      "bossId": "yeti_matriarch_heroic",
+      "factionId": "silver_guardians"
+    },
+    {
+      "id": "dungeon_5_heroic",
+      "palier": 13,
+      "name": "Scorched Caverns Héroïque",
+      "biome": "fire",
+      "damagePenetration": {
+        "type": "fire",
+        "value": 25
+      },
+      "monsters": [
+        "volcanic_imp_heroic",
+        "magma_salamander_heroic"
+      ],
+      "killTarget": 50,
+      "bossId": "inferno_elemental_lord_heroic",
+      "factionId": "magma_watchers"
+    },
+    {
+      "id": "dungeon_6_heroic",
+      "palier": 13,
+      "name": "Cinder Chambers Héroïque",
+      "biome": "fire",
+      "damagePenetration": {
+        "type": "fire",
+        "value": 25
+      },
+      "monsters": [
+        "magma_salamander_heroic",
+        "cinder_elemental_heroic"
+      ],
+      "killTarget": 50,
+      "bossId": "cinder_lord_heroic",
+      "factionId": "magma_watchers"
+    },
+    {
+      "id": "dungeon_7_heroic",
+      "palier": 14,
+      "name": "Whispering Woods Héroïque",
+      "biome": "nature",
+      "damagePenetration": {
+        "type": "nature",
+        "value": 25
+      },
+      "monsters": [
+        "cursed_sapling_heroic",
+        "thorn_boar_heroic"
+      ],
+      "killTarget": 60,
+      "bossId": "ancient_dryad_matriarch_heroic",
+      "factionId": "grove_keepers"
+    },
+    {
+      "id": "dungeon_8_heroic",
+      "palier": 14,
+      "name": "Dryad Grove Héroïque",
+      "biome": "nature",
+      "damagePenetration": {
+        "type": "nature",
+        "value": 25
+      },
+      "monsters": [
+        "thorn_boar_heroic",
+        "wandering_dryad_heroic"
+      ],
+      "killTarget": 60,
+      "bossId": "grove_protector_heroic",
+      "factionId": "grove_keepers"
+    },
+    {
+      "id": "dungeon_9_heroic",
+      "palier": 15,
+      "name": "Forgotten Crypt Héroïque",
+      "biome": "shadow",
+      "damagePenetration": {
+        "type": "shadow",
+        "value": 25
+      },
+      "monsters": [
+        "ghoul_heroic",
+        "shadow_wisp_heroic",
+        "acolyte_of_the_void_heroic"
+      ],
+      "killTarget": 70,
+      "bossId": "void_cultist_leader_heroic",
+      "factionId": "void_scholars"
+    },
+    {
+      "id": "dungeon_10_heroic",
+      "palier": 15,
+      "name": "Void Worshippers' Lair Héroïque",
+      "biome": "shadow",
+      "damagePenetration": {
+        "type": "shadow",
+        "value": 25
+      },
+      "monsters": [
+        "shadow_wisp_heroic",
+        "acolyte_of_the_void_heroic",
+        "cultist_initiate_heroic"
+      ],
+      "killTarget": 70,
+      "bossId": "void_priest_heroic",
+      "factionId": "void_scholars"
+    },
+    {
+      "id": "dungeon_11_heroic",
+      "palier": 16,
+      "name": "Glacial Depths Héroïque",
+      "biome": "ice",
+      "damagePenetration": {
+        "type": "ice",
+        "value": 25
+      },
+      "monsters": [
+        "polar_bear_heroic",
+        "glacial_elemental_heroic",
+        "ice_wraith_heroic"
+      ],
+      "killTarget": 80,
+      "bossId": "icebound_warlord_heroic",
+      "factionId": "silver_guardians"
+    },
+    {
+      "id": "dungeon_12_heroic",
+      "palier": 16,
+      "name": "Frozen Berserkers' Hall Héroïque",
+      "biome": "ice",
+      "damagePenetration": {
+        "type": "ice",
+        "value": 25
+      },
+      "monsters": [
+        "glacial_elemental_heroic",
+        "ice_wraith_heroic",
+        "frozen_berserker_heroic"
+      ],
+      "killTarget": 80,
+      "bossId": "frozen_reaver_heroic",
+      "factionId": "silver_guardians"
+    },
+    {
+      "id": "dungeon_13_heroic",
+      "palier": 17,
+      "name": "Volcanic Core Héroïque",
+      "biome": "fire",
+      "damagePenetration": {
+        "type": "fire",
+        "value": 25
+      },
+      "monsters": [
+        "pyroclastic_golem_heroic",
+        "hell_hound_heroic",
+        "obsidian_gargoyle_heroic"
+      ],
+      "killTarget": 90,
+      "bossId": "fire_giant_champion_heroic",
+      "factionId": "magma_watchers"
+    },
+    {
+      "id": "dungeon_14_heroic",
+      "palier": 17,
+      "name": "Fire Giants' Outpost Héroïque",
+      "biome": "fire",
+      "damagePenetration": {
+        "type": "fire",
+        "value": 25
+      },
+      "monsters": [
+        "hell_hound_heroic",
+        "obsidian_gargoyle_heroic",
+        "fire_giant_scout_heroic"
+      ],
+      "killTarget": 90,
+      "bossId": "magma_destroyer_heroic",
+      "factionId": "magma_watchers"
+    },
+    {
+      "id": "dungeon_15_heroic",
+      "palier": 18,
+      "name": "Verdant Labyrinth Héroïque",
+      "biome": "nature",
+      "damagePenetration": {
+        "type": "nature",
+        "value": 25
+      },
+      "monsters": [
+        "razorvine_creeper_heroic",
+        "ancient_treant_heroic",
+        "grove_sentinel_heroic"
+      ],
+      "killTarget": 100,
+      "bossId": "guardian_of_the_grove_heroic",
+      "factionId": "grove_keepers"
+    },
+    {
+      "id": "dungeon_16_heroic",
+      "palier": 18,
+      "name": "Sylvan Guardians' Domain Héroïque",
+      "biome": "nature",
+      "damagePenetration": {
+        "type": "nature",
+        "value": 25
+      },
+      "monsters": [
+        "ancient_treant_heroic",
+        "grove_sentinel_heroic",
+        "sylvan_protector_heroic"
+      ],
+      "killTarget": 100,
+      "bossId": "sylvan_sentinel_heroic",
+      "factionId": "grove_keepers"
+    },
+    {
+      "id": "dungeon_17_heroic",
+      "palier": 19,
+      "name": "Shadowy Necropolis Héroïque",
+      "biome": "shadow",
+      "damagePenetration": {
+        "type": "shadow",
+        "value": 25
+      },
+      "monsters": [
+        "wraith_heroic",
+        "mind_flayer_spawn_heroic",
+        "void_terror_heroic",
+        "shambling_horror_heroic"
+      ],
+      "killTarget": 110,
+      "bossId": "spectral_overlord_heroic",
+      "factionId": "void_scholars"
+    },
+    {
+      "id": "dungeon_18_heroic",
+      "palier": 19,
+      "name": "Specters' Sanctuary Héroïque",
+      "biome": "shadow",
+      "damagePenetration": {
+        "type": "shadow",
+        "value": 25
+      },
+      "monsters": [
+        "mind_flayer_spawn_heroic",
+        "void_terror_heroic",
+        "shambling_horror_heroic",
+        "specter_heroic"
+      ],
+      "killTarget": 110,
+      "bossId": "nether_lich_heroic",
+      "factionId": "void_scholars"
+    },
+    {
+      "id": "dungeon_19_heroic",
+      "palier": 20,
+      "name": "Frozen Wastes Héroïque",
+      "biome": "ice",
+      "damagePenetration": {
+        "type": "ice",
+        "value": 25
+      },
+      "monsters": [
+        "frost_giant_heroic",
+        "rime-scaled_drake_heroic",
+        "mammoth_calf_heroic",
+        "wendigo_spawn_heroic"
+      ],
+      "killTarget": 120,
+      "bossId": "boreal_crusader_heroic",
+      "factionId": "silver_guardians"
+    },
+    {
+      "id": "dungeon_20_heroic",
+      "palier": 20,
+      "name": "Boreal Knights' Fortress Héroïque",
+      "biome": "ice",
+      "damagePenetration": {
+        "type": "ice",
+        "value": 25
+      },
+      "monsters": [
+        "rime-scaled_drake_heroic",
+        "mammoth_calf_heroic",
+        "wendigo_spawn_heroic",
+        "boreal_knight_heroic"
+      ],
+      "killTarget": 120,
+      "bossId": "tundra_king_heroic",
+      "factionId": "silver_guardians"
+    },
+    {
+      "id": "dungeon_21_heroic",
+      "palier": 21,
+      "name": "Infernal Forge Héroïque",
+      "biome": "fire",
+      "damagePenetration": {
+        "type": "fire",
+        "value": 25
+      },
+      "monsters": [
+        "infernal_juggernaut_heroic",
+        "magma_dragon_whelp_heroic",
+        "flame_hydra_heroic",
+        "brimstone_devil_heroic"
+      ],
+      "killTarget": 130,
+      "bossId": "ashwing_matriarch_heroic",
+      "factionId": "magma_watchers"
+    },
+    {
+      "id": "dungeon_22_heroic",
+      "palier": 21,
+      "name": "Ash Harpies' Nest Héroïque",
+      "biome": "fire",
+      "damagePenetration": {
+        "type": "fire",
+        "value": 25
+      },
+      "monsters": [
+        "magma_dragon_whelp_heroic",
+        "flame_hydra_heroic",
+        "brimstone_devil_heroic",
+        "ash_harpy_heroic"
+      ],
+      "killTarget": 130,
+      "bossId": "emberwing_scion_heroic",
+      "factionId": "magma_watchers"
+    },
+    {
+      "id": "dungeon_23_heroic",
+      "palier": 22,
+      "name": "Emerald Nightmare Héroïque",
+      "biome": "nature",
+      "damagePenetration": {
+        "type": "nature",
+        "value": 25
+      },
+      "monsters": [
+        "colossal_carnivorous_plant_heroic",
+        "verdant_wyrm_heroic",
+        "elf_ranger_heroic",
+        "satyr_trickster_heroic"
+      ],
+      "killTarget": 140,
+      "bossId": "colossus_of_the_grove_heroic",
+      "factionId": "grove_keepers"
+    },
+    {
+      "id": "dungeon_24_heroic",
+      "palier": 22,
+      "name": "Emerald Golems' Garden Héroïque",
+      "biome": "nature",
+      "damagePenetration": {
+        "type": "nature",
+        "value": 25
+      },
+      "monsters": [
+        "verdant_wyrm_heroic",
+        "elf_ranger_heroic",
+        "satyr_trickster_heroic",
+        "emerald_golem_heroic"
+      ],
+      "killTarget": 140,
+      "bossId": "emerald_titan_heroic",
+      "factionId": "grove_keepers"
+    },
+    {
+      "id": "dungeon_25_heroic",
+      "palier": 23,
+      "name": "Cathedral of Eternal Night Héroïque",
+      "biome": "shadow",
+      "damagePenetration": {
+        "type": "shadow",
+        "value": 25
+      },
+      "monsters": [
+        "dread_lich_heroic",
+        "elder_thing_heroic",
+        "void_reaver_heroic",
+        "bone_collector_heroic",
+        "soul_eater_heroic"
+      ],
+      "killTarget": 150,
+      "bossId": "ancient_tomb_protector_heroic",
+      "factionId": "void_scholars"
+    },
+    {
+      "id": "dungeon_26_heroic",
+      "palier": 23,
+      "name": "Tomb Guardians' Crypt Héroïque",
+      "biome": "shadow",
+      "damagePenetration": {
+        "type": "shadow",
+        "value": 25
+      },
+      "monsters": [
+        "elder_thing_heroic",
+        "void_reaver_heroic",
+        "bone_collector_heroic",
+        "soul_eater_heroic",
+        "tomb_guardian_heroic"
+      ],
+      "killTarget": 150,
+      "bossId": "crypt_lord_heroic",
+      "factionId": "void_scholars"
+    },
+    {
+      "id": "dungeon_27_heroic",
+      "palier": 24,
+      "name": "Glacier's Peak Héroïque",
+      "biome": "ice",
+      "damagePenetration": {
+        "type": "ice",
+        "value": 25
+      },
+      "monsters": [
+        "ice_titan_heroic",
+        "avalanche_spirit_heroic",
+        "yeti_patriarch_heroic",
+        "frost-forged_sentinel_heroic",
+        "seraphim_of_ice_heroic"
+      ],
+      "killTarget": 160,
+      "bossId": "ancient_frost_wyrm_heroic",
+      "factionId": "silver_guardians"
+    },
+    {
+      "id": "dungeon_28_heroic",
+      "palier": 24,
+      "name": "Frost Wyrm's Lair Héroïque",
+      "biome": "ice",
+      "damagePenetration": {
+        "type": "ice",
+        "value": 25
+      },
+      "monsters": [
+        "avalanche_spirit_heroic",
+        "yeti_patriarch_heroic",
+        "frost-forged_sentinel_heroic",
+        "seraphim_of_ice_heroic",
+        "ancient_frost_wyrm_heroic"
+      ],
+      "killTarget": 160,
+      "bossId": "glacial_behemoth_heroic",
+      "factionId": "silver_guardians"
+    },
+    {
+      "id": "dungeon_29_heroic",
+      "palier": 25,
+      "name": "Heart of the Volcano Héroïque",
+      "biome": "fire",
+      "damagePenetration": {
+        "type": "fire",
+        "value": 25
+      },
+      "monsters": [
+        "balrog_heroic",
+        "phoenix_heroic",
+        "efreeti_sultan_heroic",
+        "volcanic_titan_heroic",
+        "charred_legionnaire_heroic"
+      ],
+      "killTarget": 170,
+      "bossId": "primeval_magma_dragon_heroic",
+      "factionId": "magma_watchers"
+    },
+    {
+      "id": "dungeon_30_heroic",
+      "palier": 25,
+      "name": "Magma Dragon's Roost Héroïque",
+      "biome": "fire",
+      "damagePenetration": {
+        "type": "fire",
+        "value": 25
+      },
+      "monsters": [
+        "phoenix_heroic",
+        "efreeti_sultan_heroic",
+        "volcanic_titan_heroic",
+        "charred_legionnaire_heroic",
+        "primeval_magma_dragon_heroic"
+      ],
+      "killTarget": 170,
+      "bossId": "volcanic_annihilator_heroic",
+      "factionId": "magma_watchers"
+    },
+    {
+      "id": "dungeon_31_heroic",
+      "palier": 26,
+      "name": "Throne of the Wilds Héroïque",
+      "biome": "nature",
+      "damagePenetration": {
+        "type": "nature",
+        "value": 25
+      },
+      "monsters": [
+        "gaia_avatar_heroic",
+        "archdruid_of_the_fang_heroic",
+        "fenrir's_chosen_heroic",
+        "fae_king_heroic",
+        "living_world-tree_heroic"
+      ],
+      "killTarget": 180,
+      "bossId": "world_ash_treant_heroic",
+      "factionId": "grove_keepers"
+    },
+    {
+      "id": "dungeon_32_heroic",
+      "palier": 26,
+      "name": "World Ash Treant's Grove Héroïque",
+      "biome": "nature",
+      "damagePenetration": {
+        "type": "nature",
+        "value": 25
+      },
+      "monsters": [
+        "archdruid_of_the_fang_heroic",
+        "fenrir's_chosen_heroic",
+        "fae_king_heroic",
+        "living_world-tree_heroic",
+        "world_ash_treant_heroic"
+      ],
+      "killTarget": 180,
+      "bossId": "verdant_colossus_heroic",
+      "factionId": "grove_keepers"
+    },
+    {
+      "id": "dungeon_33_heroic",
+      "palier": 27,
+      "name": "The Void-Corrupted Sanctum Héroïque",
+      "biome": "shadow",
+      "damagePenetration": {
+        "type": "shadow",
+        "value": 25
+      },
+      "monsters": [
+        "archlich_of_nar'thalas_heroic",
+        "gibbering_mouther_heroic",
+        "void_leviathan_heroic",
+        "ethereal_devourer_heroic",
+        "shadow_titan_heroic",
+        "death_knight_champion_heroic"
+      ],
+      "killTarget": 190,
+      "bossId": "herald_of_cthulhu_heroic",
+      "factionId": "void_scholars"
+    },
+    {
+      "id": "dungeon_34_heroic",
+      "palier": 27,
+      "name": "Cthulhu's Herald's Antechamber Héroïque",
+      "biome": "shadow",
+      "damagePenetration": {
+        "type": "shadow",
+        "value": 25
+      },
+      "monsters": [
+        "gibbering_mouther_heroic",
+        "void_leviathan_heroic",
+        "ethereal_devourer_heroic",
+        "shadow_titan_heroic",
+        "death_knight_champion_heroic",
+        "herald_of_cthulhu_heroic"
+      ],
+      "killTarget": 190,
+      "bossId": "void_harbinger_heroic",
+      "factionId": "void_scholars"
+    },
+    {
+      "id": "dungeon_35_heroic",
+      "palier": 28,
+      "name": "Permafrost Citadel Héroïque",
+      "biome": "ice",
+      "damagePenetration": {
+        "type": "ice",
+        "value": 25
+      },
+      "monsters": [
+        "ancient_frost_wyrm_heroic",
+        "ice_titan_heroic",
+        "seraphim_of_ice_heroic"
+      ],
+      "killTarget": 200,
+      "bossId": "icecrown_sentinel_heroic",
+      "factionId": "silver_guardians"
+    },
+    {
+      "id": "dungeon_36_heroic",
+      "palier": 28,
+      "name": "Molten Pinnacle Héroïque",
+      "biome": "fire",
+      "damagePenetration": {
+        "type": "fire",
+        "value": 25
+      },
+      "monsters": [
+        "primeval_magma_dragon_heroic",
+        "balrog_heroic",
+        "phoenix_heroic"
+      ],
+      "killTarget": 200,
+      "bossId": "infernal_reaver_heroic",
+      "factionId": "magma_watchers"
+    },
+    {
+      "id": "dungeon_37_heroic",
+      "palier": 29,
+      "name": "Heart of the Forest Héroïque",
+      "biome": "nature",
+      "damagePenetration": {
+        "type": "nature",
+        "value": 25
+      },
+      "monsters": [
+        "world_ash_treant_heroic",
+        "gaia_avatar_heroic",
+        "fae_king_heroic"
+      ],
+      "killTarget": 200,
+      "bossId": "emerald_dreamer_heroic",
+      "factionId": "grove_keepers"
+    },
+    {
+      "id": "dungeon_38_heroic",
+      "palier": 29,
+      "name": "R'lyeh's Threshold Héroïque",
+      "biome": "shadow",
+      "damagePenetration": {
+        "type": "shadow",
+        "value": 25
+      },
+      "monsters": [
+        "herald_of_cthulhu_heroic",
+        "void_leviathan_heroic",
+        "archlich_of_nar'thalas_heroic"
+      ],
+      "killTarget": 200,
+      "bossId": "sunken_horror_heroic",
+      "factionId": "void_scholars"
+    },
+    {
+      "id": "dungeon_39_heroic",
+      "palier": 30,
+      "name": "Frozen Throne Héroïque",
+      "biome": "ice",
+      "damagePenetration": {
+        "type": "ice",
+        "value": 25
+      },
+      "monsters": [
+        "ancient_frost_wyrm_heroic",
+        "ice_titan_heroic",
+        "seraphim_of_ice_heroic",
+        "boreal_knight_heroic"
+      ],
+      "killTarget": 200,
+      "bossId": "frostlord_heroic",
+      "factionId": "silver_guardians"
+    },
+    {
+      "id": "dungeon_40_heroic",
+      "palier": 30,
+      "name": "Inferno's Core Héroïque",
+      "biome": "fire",
+      "damagePenetration": {
+        "type": "fire",
+        "value": 25
+      },
+      "monsters": [
+        "primeval_magma_dragon_heroic",
+        "balrog_heroic",
+        "phoenix_heroic",
+        "efreeti_sultan_heroic"
+      ],
+      "killTarget": 200,
+      "bossId": "blackrock_tyrant_heroic",
+      "factionId": "magma_watchers"
+    },
+    {
+      "id": "dungeon_41_heroic",
+      "palier": 31,
+      "name": "Verdant Sanctuary Héroïque",
+      "biome": "nature",
+      "damagePenetration": {
+        "type": "nature",
+        "value": 25
+      },
+      "monsters": [
+        "world_ash_treant_heroic",
+        "gaia_avatar_heroic",
+        "fae_king_heroic",
+        "archdruid_of_the_fang_heroic"
+      ],
+      "killTarget": 200,
+      "bossId": "sylvan_goliath_heroic",
+      "factionId": "grove_keepers"
+    },
+    {
+      "id": "dungeon_42_heroic",
+      "palier": 31,
+      "name": "The Sunken City Héroïque",
+      "biome": "shadow",
+      "damagePenetration": {
+        "type": "shadow",
+        "value": 25
+      },
+      "monsters": [
+        "herald_of_cthulhu_heroic",
+        "void_leviathan_heroic",
+        "archlich_of_nar'thalas_heroic",
+        "shadow_titan_heroic"
+      ],
+      "killTarget": 200,
+      "bossId": "nyalotha_prophet_heroic",
+      "factionId": "void_scholars"
+    },
+    {
+      "id": "dungeon_43_heroic",
+      "palier": 32,
+      "name": "Icecrown Citadel Héroïque",
+      "biome": "ice",
+      "damagePenetration": {
+        "type": "ice",
+        "value": 25
+      },
+      "monsters": [
+        "ancient_frost_wyrm_heroic",
+        "ice_titan_heroic",
+        "seraphim_of_ice_heroic",
+        "boreal_knight_heroic",
+        "yeti_patriarch_heroic"
+      ],
+      "killTarget": 200,
+      "bossId": "rimefang_heroic",
+      "factionId": "silver_guardians"
+    },
+    {
+      "id": "dungeon_44_heroic",
+      "palier": 32,
+      "name": "Blackrock Mountain Héroïque",
+      "biome": "fire",
+      "damagePenetration": {
+        "type": "fire",
+        "value": 25
+      },
+      "monsters": [
+        "primeval_magma_dragon_heroic",
+        "balrog_heroic",
+        "phoenix_heroic",
+        "efreeti_sultan_heroic",
+        "volcanic_titan_heroic"
+      ],
+      "killTarget": 200,
+      "bossId": "molten_leviathan_heroic",
+      "factionId": "magma_watchers"
+    },
+    {
+      "id": "dungeon_45_heroic",
+      "palier": 33,
+      "name": "The Emerald Dream Héroïque",
+      "biome": "nature",
+      "damagePenetration": {
+        "type": "nature",
+        "value": 25
+      },
+      "monsters": [
+        "world_ash_treant_heroic",
+        "gaia_avatar_heroic",
+        "fae_king_heroic",
+        "archdruid_of_the_fang_heroic",
+        "fenrir's_chosen_heroic"
+      ],
+      "killTarget": 200,
+      "bossId": "heart_of_the_forest_heroic",
+      "factionId": "grove_keepers"
+    },
+    {
+      "id": "dungeon_46_heroic",
+      "palier": 33,
+      "name": "Ny'alotha, the Waking City Héroïque",
+      "biome": "shadow",
+      "damagePenetration": {
+        "type": "shadow",
+        "value": 25
+      },
+      "monsters": [
+        "herald_of_cthulhu_heroic",
+        "void_leviathan_heroic",
+        "archlich_of_nar'thalas_heroic",
+        "shadow_titan_heroic",
+        "death_knight_champion_heroic"
+      ],
+      "killTarget": 200,
+      "bossId": "shadow_of_rlyeh_heroic",
+      "factionId": "void_scholars"
+    },
+    {
+      "id": "dungeon_47_heroic",
+      "palier": 34,
+      "name": "The Frozen Halls Héroïque",
+      "biome": "ice",
+      "damagePenetration": {
+        "type": "ice",
+        "value": 25
+      },
+      "monsters": [
+        "ancient_frost_wyrm_heroic",
+        "ice_titan_heroic",
+        "seraphim_of_ice_heroic",
+        "boreal_knight_heroic",
+        "yeti_patriarch_heroic",
+        "frost-forged_sentinel_heroic"
+      ],
+      "killTarget": 200,
+      "bossId": "frozen_terror_heroic",
+      "factionId": "silver_guardians"
+    },
+    {
+      "id": "dungeon_48_heroic",
+      "palier": 35,
+      "name": "The Molten Core Héroïque",
+      "biome": "fire",
+      "damagePenetration": {
+        "type": "fire",
+        "value": 25
+      },
+      "monsters": [
+        "primeval_magma_dragon_heroic",
+        "balrog_heroic",
+        "phoenix_heroic",
+        "efreeti_sultan_heroic",
+        "volcanic_titan_heroic",
+        "charred_legionnaire_heroic"
+      ],
+      "killTarget": 200,
+      "bossId": "blazing_juggernaut_heroic",
+      "factionId": "magma_watchers"
+    }
+  ]
 }

--- a/public/data/monsters.json
+++ b/public/data/monsters.json
@@ -1,1235 +1,5926 @@
 {
-    "monsters": [
-        {
-            "id": "goblin_scout",
-            "nom": "Goblin Scout",
-            "level": 1,
-            "famille": "Goblinoid",
-            "isBoss": false,
-            "palier": 1,
-            "stats": { "PV": 30, "AttMin": 5, "AttMax": 8, "CritPct": 5, "CritDmg": 150, "Armure": 10, "Vitesse": 2.5, "Precision": 50, "Esquive": 5 }
-        },
-        {
-            "id": "giant_rat",
-            "nom": "Giant Rat",
-            "level": 1,
-            "famille": "Beast",
-            "isBoss": false,
-            "palier": 1,
-            "stats": { "PV": 25, "AttMin": 4, "AttMax": 7, "CritPct": 3, "CritDmg": 150, "Armure": 5, "Vitesse": 2.2, "Precision": 45, "Esquive": 8 },
-            "componentLoot": [
-                { "id": "light_leather", "chance": 0.3, "quantity": 1 }
-            ]
-        },
-        {
-            "id": "kobold_miner_supervisor",
-            "nom": "Kobold Miner SUPERVISOR",
-            "famille": "Humanoid",
-            "level": 3,
-            "isBoss": true,
-            "palier": 1,
-            "stats": { "PV": 150, "AttMin": 12, "AttMax": 18, "CritPct": 10, "CritDmg": 150, "Armure": 50, "Vitesse": 2.5, "Precision": 65, "Esquive": 5 },
-            "abilities": [{
-                "id": "get_back_to_work", "name": "Au travail !", "cooldown": 15, "chance": 0.3,
-                "effects": [{ "type": "debuff", "debuffType": "cc", "id": "supervisor_stun", "name": "Intimidation", "duration": 1.5, "ccType": "stun" }]
-            }]
-        },
-        {
-            "id": "kobold_miner_assistant",
-            "nom": "Kobold Miner assistant",
-            "level": 2,
-            "famille": "Humanoid",
-            "isBoss": false,
-            "palier": 1,
-            "stats": { "PV": 40, "AttMin": 6, "AttMax": 9, "CritPct": 5, "CritDmg": 150, "Armure": 20, "Vitesse": 2.8, "Precision": 55, "Esquive": 3 },
-            "componentLoot": [
-                { "id": "copper_ingot", "chance": 0.4, "quantity": 1 }
-            ]
-        },
-        {
-            "id": "cave_bat",
-            "nom": "Cave Bat",
-            "level": 3,
-            "famille": "Beast",
-            "isBoss": false,
-            "palier": 1,
-            "stats": { "PV": 35, "AttMin": 7, "AttMax": 10, "CritPct": 8, "CritDmg": 150, "Armure": 10, "Vitesse": 1.8, "Precision": 60, "Esquive": 15 },
-            "questItemId": "bat_fang",
-            "componentLoot": [
-                { "id": "light_leather", "chance": 0.35, "quantity": 1 }
-            ]
-        },
-        {
-            "id": "frost_wolf",
-            "nom": "Frost Wolf",
-            "level": 4,
-            "famille": "Beast",
-            "isBoss": false,
-            "palier": 2,
-            "stats": { "PV": 80, "AttMin": 12, "AttMax": 18, "CritPct": 10, "CritDmg": 150, "Armure": 40, "Vitesse": 2.2, "Precision": 65, "Esquive": 10 }
-        },
-        {
-            "id": "ice_sprite",
-            "nom": "Ice Sprite",
-            "level": 5,
-            "famille": "Elemental",
-            "isBoss": false,
-            "palier": 2,
-            "stats": { "PV": 60, "AttMin": 15, "AttMax": 20, "CritPct": 5, "CritDmg": 150, "Armure": 25, "Vitesse": 2, "Precision": 70, "Esquive": 18, "ResElems": { "ice": 25, "fire": -10 } }
-        },
-        {
-            "id": "yeti_toddler",
-            "nom": "Yeti Toddler",
-            "level": 6,
-            "famille": "Giant",
-            "isBoss": false,
-            "palier": 2,
-            "stats": { "PV": 150, "AttMin": 10, "AttMax": 15, "CritPct": 3, "CritDmg": 150, "Armure": 60, "Vitesse": 3, "Precision": 60, "Esquive": 5 }
-        },
-        {
-            "id": "volcanic_imp",
-            "nom": "Volcanic Imp",
-            "level": 7,
-            "famille": "Demon",
-            "isBoss": false,
-            "palier": 3,
-            "stats": { "PV": 120, "AttMin": 20, "AttMax": 25, "CritPct": 8, "CritDmg": 160, "Armure": 50, "Vitesse": 2.1, "Precision": 75, "Esquive": 12 }
-        },
-        {
-            "id": "magma_salamander",
-            "nom": "Magma Salamander",
-            "level": 8,
-            "famille": "Elemental",
-            "isBoss": false,
-            "palier": 3,
-            "stats": { "PV": 180, "AttMin": 18, "AttMax": 28, "CritPct": 5, "CritDmg": 150, "Armure": 70, "Vitesse": 2.8, "Precision": 70, "Esquive": 8 }
-        },
-        {
-            "id": "cinder_elemental",
-            "nom": "Cinder Elemental",
-            "level": 9,
-            "famille": "Elemental",
-            "isBoss": false,
-            "palier": 3,
-            "stats": { "PV": 150, "AttMin": 25, "AttMax": 30, "CritPct": 5, "CritDmg": 150, "Armure": 40, "Vitesse": 2.5, "Precision": 75, "Esquive": 10, "ResElems": { "fire": 25, "ice": -10 } },
-            "componentLoot": [
-                { "id": "eternal_fire", "chance": 0.15, "quantity": 1 }
-            ]
-        },
-        {
-            "id": "cursed_sapling",
-            "nom": "Cursed Sapling",
-            "level": 10,
-            "famille": "Plant",
-            "isBoss": false,
-            "palier": 4,
-            "stats": { "PV": 250, "AttMin": 28, "AttMax": 35, "CritPct": 5, "CritDmg": 150, "Armure": 100, "Vitesse": 3, "Precision": 75, "Esquive": 5 }
-        },
-        {
-            "id": "thorn_boar",
-            "nom": "Thorn Boar",
-            "level": 11,
-            "famille": "Beast",
-            "isBoss": false,
-            "palier": 4,
-            "stats": { "PV": 300, "AttMin": 30, "AttMax": 40, "CritPct": 8, "CritDmg": 150, "Armure": 120, "Vitesse": 2.6, "Precision": 70, "Esquive": 8 }
-        },
-        {
-            "id": "wandering_dryad",
-            "nom": "Wandering Dryad",
-            "level": 12,
-            "famille": "Fey",
-            "isBoss": false,
-            "palier": 4,
-            "stats": { "PV": 220, "AttMin": 35, "AttMax": 45, "CritPct": 10, "CritDmg": 160, "Armure": 80, "Vitesse": 2.2, "Precision": 80, "Esquive": 15 }
-        },
-        {
-            "id": "ghoul",
-            "nom": "Ghoul",
-            "level": 13,
-            "famille": "Undead",
-            "isBoss": false,
-            "palier": 5,
-            "stats": { "PV": 400, "AttMin": 40, "AttMax": 50, "CritPct": 7, "CritDmg": 150, "Armure": 150, "Vitesse": 2.8, "Precision": 80, "Esquive": 10 }
-        },
-        {
-            "id": "shadow_wisp",
-            "nom": "Shadow Wisp",
-            "level": 14,
-            "famille": "Aberration",
-            "isBoss": false,
-            "palier": 5,
-            "stats": { "PV": 300, "AttMin": 50, "AttMax": 60, "CritPct": 12, "CritDmg": 170, "Armure": 100, "Vitesse": 1.9, "Precision": 85, "Esquive": 20, "ResElems": { "shadow": 25 } },
-            "componentLoot": [
-                { "id": "frozen_shadow", "chance": 0.1, "quantity": 1 }
-            ]
-        },
-        {
-            "id": "acolyte_of_the_void",
-            "nom": "Acolyte of the Void",
-            "level": 15,
-            "famille": "Humanoid",
-            "isBoss": false,
-            "palier": 5,
-            "stats": { "PV": 350, "AttMin": 45, "AttMax": 55, "CritPct": 10, "CritDmg": 160, "Armure": 120, "Vitesse": 2.4, "Precision": 85, "Esquive": 15 }
-        },
-        {
-            "id": "cultist_initiate",
-            "nom": "Cultist Initiate",
-            "level": 15,
-            "famille": "Humanoid",
-            "isBoss": false,
-            "palier": 5,
-            "stats": { "PV": 380, "AttMin": 42, "AttMax": 53, "CritPct": 8, "CritDmg": 150, "Armure": 140, "Vitesse": 2.6, "Precision": 82, "Esquive": 12 }
-        },
-        {
-            "id": "polar_bear",
-            "nom": "Polar Bear",
-            "level": 16,
-            "famille": "Beast",
-            "isBoss": false,
-            "palier": 6,
-            "stats": { "PV": 550, "AttMin": 55, "AttMax": 70, "CritPct": 8, "CritDmg": 150, "Armure": 250, "Vitesse": 2.9, "Precision": 80, "Esquive": 10 }
-        },
-        {
-            "id": "glacial_elemental",
-            "nom": "Glacial Elemental",
-            "level": 17,
-            "famille": "Elemental",
-            "isBoss": false,
-            "palier": 6,
-            "stats": { "PV": 450, "AttMin": 65, "AttMax": 80, "CritPct": 5, "CritDmg": 150, "Armure": 180, "Vitesse": 2.7, "Precision": 85, "Esquive": 15, "ResElems": { "ice": 30, "fire": -15 } },
-            "componentLoot": [
-                { "id": "crystalline_water", "chance": 0.15, "quantity": 1 }
-            ]
-        },
-        {
-            "id": "ice_wraith",
-            "nom": "Ice Wraith",
-            "level": 18,
-            "famille": "Undead",
-            "isBoss": false,
-            "palier": 6,
-            "stats": { "PV": 400, "AttMin": 70, "AttMax": 85, "CritPct": 12, "CritDmg": 160, "Armure": 150, "Vitesse": 2.2, "Precision": 90, "Esquive": 22 },
-            "abilities": [
-                {
-                    "id": "monster_frost_attack",
-                    "name": "Attaque de givre",
-                    "cooldown": 10,
-                    "chance": 0.5,
-                    "effects": [
-                        {
-                            "type": "debuff",
-                            "debuffType": "stat_modifier",
-                            "id": "monster_frost_slow",
-                            "name": "Ralentissement glacial",
-                            "duration": 6,
-                            "statMods": [
-                                { "stat": "Vitesse", "modifier": "multiplicative", "value": 1.30 }
-                            ]
-                        }
-                    ]
-                }
-            ]
-        },
-        {
-            "id": "frozen_berserker",
-            "nom": "Frozen Berserker",
-            "level": 18,
-            "famille": "Humanoid",
-            "isBoss": false,
-            "palier": 6,
-            "stats": { "PV": 600, "AttMin": 60, "AttMax": 75, "CritPct": 10, "CritDmg": 150, "Armure": 220, "Vitesse": 3, "Precision": 82, "Esquive": 8 }
-        },
-        {
-            "id": "pyroclastic_golem",
-            "nom": "Pyroclastic Golem",
-            "level": 19,
-            "famille": "Construct",
-            "isBoss": false,
-            "palier": 7,
-            "stats": { "PV": 800, "AttMin": 75, "AttMax": 90, "CritPct": 5, "CritDmg": 150, "Armure": 400, "Vitesse": 3.5, "Precision": 85, "Esquive": 5 }
-        },
-        {
-            "id": "hell_hound",
-            "nom": "Hell Hound",
-            "level": 20,
-            "famille": "Beast",
-            "isBoss": false,
-            "palier": 7,
-            "stats": { "PV": 550, "AttMin": 76, "AttMax": 90, "CritPct": 15, "CritDmg": 170, "Armure": 280, "Vitesse": 2.3, "Precision": 90, "Esquive": 18 },
-            "abilities": [
-                {
-                    "id": "monster_fire_breath",
-                    "name": "Souffle de feu",
-                    "cooldown": 12,
-                    "chance": 0.4,
-                    "effects": [
-                        {
-                            "type": "debuff",
-                            "debuffType": "dot",
-                            "id": "monster_fire_dot",
-                            "name": "Brûlure infernale",
-                            "duration": 9,
-                            "damageType": "fire",
-                            "totalDamage": {
-                                "source": "base_value",
-                                "multiplier": 45
-                            }
-                        }
-                    ]
-                }
-            ]
-        },
-        {
-            "id": "obsidian_gargoyle",
-            "nom": "Obsidian Gargoyle",
-            "level": 21,
-            "famille": "Construct",
-            "isBoss": false,
-            "palier": 7,
-            "stats": { "PV": 600, "AttMin": 74, "AttMax": 87, "CritPct": 8, "CritDmg": 150, "Armure": 350, "Vitesse": 2.8, "Precision": 88, "Esquive": 12 }
-        },
-        {
-            "id": "fire_giant_scout",
-            "nom": "Fire Giant Scout",
-            "level": 21,
-            "famille": "Giant",
-            "isBoss": false,
-            "palier": 7,
-            "stats": { "PV": 765, "AttMin": 80, "AttMax": 95, "CritPct": 7, "CritDmg": 150, "Armure": 380, "Vitesse": 3.2, "Precision": 85, "Esquive": 7 }
-        },
-        {
-            "id": "razorvine_creeper",
-            "nom": "Razorvine Creeper",
-            "level": 22,
-            "famille": "Plant",
-            "isBoss": false,
-            "palier": 8,
-            "stats": { "PV": 720, "AttMin": 85, "AttMax": 104, "CritPct": 10, "CritDmg": 160, "Armure": 300, "Vitesse": 2.5, "Precision": 90, "Esquive": 15 }
-        },
-        {
-            "id": "ancient_treant",
-            "nom": "Ancient Treant",
-            "level": 23,
-            "famille": "Plant",
-            "isBoss": false,
-            "palier": 8,
-            "stats": { "PV": 1020, "AttMin": 95, "AttMax": 114, "CritPct": 5, "CritDmg": 150, "Armure": 500, "Vitesse": 4, "Precision": 90, "Esquive": 5 }
-        },
-        {
-            "id": "grove_sentinel",
-            "nom": "Grove Sentinel",
-            "level": 24,
-            "famille": "Construct",
-            "isBoss": false,
-            "palier": 8,
-            "stats": { "PV": 850, "AttMin": 90, "AttMax": 109, "CritPct": 7, "CritDmg": 150, "Armure": 450, "Vitesse": 3.3, "Precision": 88, "Esquive": 8 }
-        },
-        {
-            "id": "sylvan_protector",
-            "nom": "Sylvan Protector",
-            "level": 24,
-            "famille": "Fey",
-            "isBoss": false,
-            "palier": 8,
-            "stats": { "PV": 765, "AttMin": 99, "AttMax": 118, "CritPct": 12, "CritDmg": 160, "Armure": 350, "Vitesse": 2.4, "Precision": 92, "Esquive": 18 }
-        },
-        {
-            "id": "wraith",
-            "nom": "Wraith",
-            "level": 25,
-            "famille": "Undead",
-            "isBoss": false,
-            "palier": 9,
-            "stats": { "PV": 800, "AttMin": 114, "AttMax": 133, "CritPct": 15, "CritDmg": 180, "Armure": 300, "Vitesse": 2, "Precision": 95, "Esquive": 25 },
-            "componentLoot": [
-                { "id": "frozen_shadow", "chance": 0.1, "quantity": 1 }
-            ]
-        },
-        {
-            "id": "mind_flayer_spawn",
-            "nom": "Mind Flayer Spawn",
-            "level": 26,
-            "famille": "Aberration",
-            "isBoss": false,
-            "palier": 9,
-            "stats": { "PV": 935, "AttMin": 104, "AttMax": 123, "CritPct": 10, "CritDmg": 160, "Armure": 350, "Vitesse": 2.6, "Precision": 95, "Esquive": 15 }
-        },
-        {
-            "id": "void_terror",
-            "nom": "Void Terror",
-            "level": 27,
-            "famille": "Aberration",
-            "isBoss": false,
-            "palier": 9,
-            "stats": { "PV": 1275, "AttMin": 118, "AttMax": 142, "CritPct": 8, "CritDmg": 150, "Armure": 500, "Vitesse": 3.1, "Precision": 92, "Esquive": 10 }
-        },
-        {
-            "id": "shambling_horror",
-            "nom": "Shambling Horror",
-            "level": 27,
-            "famille": "Aberration",
-            "isBoss": false,
-            "palier": 9,
-            "stats": { "PV": 1360, "AttMin": 114, "AttMax": 137, "CritPct": 5, "CritDmg": 150, "Armure": 550, "Vitesse": 3.8, "Precision": 90, "Esquive": 5 }
-        },
-        {
-            "id": "specter",
-            "nom": "Specter",
-            "level": 27,
-            "famille": "Undead",
-            "isBoss": false,
-            "palier": 9,
-            "stats": { "PV": 765, "AttMin": 123, "AttMax": 147, "CritPct": 18, "CritDmg": 180, "Armure": 280, "Vitesse": 1.8, "Precision": 98, "Esquive": 30 }
-        },
-        {
-            "id": "frost_giant",
-            "nom": "Frost Giant",
-            "level": 28,
-            "famille": "Giant",
-            "isBoss": false,
-            "palier": 10,
-            "stats": { "PV": 1700, "AttMin": 142, "AttMax": 171, "CritPct": 8, "CritDmg": 150, "Armure": 700, "Vitesse": 3.5, "Precision": 95, "Esquive": 8 }
-        },
-        {
-            "id": "rime-scaled_drake",
-            "nom": "Rime-scaled Drake",
-            "level": 29,
-            "famille": "Dragonkin",
-            "isBoss": false,
-            "palier": 10,
-            "stats": { "PV": 1530, "AttMin": 152, "AttMax": 180, "CritPct": 12, "CritDmg": 160, "Armure": 600, "Vitesse": 2.8, "Precision": 98, "Esquive": 15 }
-        },
-        {
-            "id": "mammoth_calf",
-            "nom": "Mammoth Calf",
-            "level": 30,
-            "famille": "Beast",
-            "isBoss": false,
-            "palier": 10,
-            "stats": { "PV": 2050, "AttMin": 128, "AttMax": 156, "CritPct": 5, "CritDmg": 150, "Armure": 800, "Vitesse": 4, "Precision": 90, "Esquive": 5 }
-        },
-        {
-            "id": "wendigo_spawn",
-            "nom": "Wendigo Spawn",
-            "level": 30,
-            "famille": "Aberration",
-            "isBoss": false,
-            "palier": 10,
-            "stats": { "PV": 1400, "AttMin": 156, "AttMax": 184, "CritPct": 18, "CritDmg": 170, "Armure": 550, "Vitesse": 2.5, "Precision": 100, "Esquive": 20 }
-        },
-        {
-            "id": "boreal_knight",
-            "nom": "Boreal Knight",
-            "level": 30,
-            "famille": "Humanoid",
-            "isBoss": false,
-            "palier": 10,
-            "stats": { "PV": 1800, "AttMin": 142, "AttMax": 170, "CritPct": 10, "CritDmg": 150, "Armure": 750, "Vitesse": 3, "Precision": 95, "Esquive": 12 }
-        },
-        {
-            "id": "infernal_juggernaut",
-            "nom": "Infernal Juggernaut",
-            "level": 31,
-            "famille": "Demon",
-            "isBoss": false,
-            "palier": 11,
-            "stats": { "PV": 2460, "AttMin": 165, "AttMax": 193, "CritPct": 7, "CritDmg": 150, "Armure": 1000, "Vitesse": 3.8, "Precision": 98, "Esquive": 7 }
-        },
-        {
-            "id": "magma_dragon_whelp",
-            "nom": "Magma Dragon Whelp",
-            "level": 32,
-            "famille": "Dragonkin",
-            "isBoss": false,
-            "palier": 11,
-            "stats": { "PV": 2050, "AttMin": 174, "AttMax": 202, "CritPct": 12, "CritDmg": 160, "Armure": 850, "Vitesse": 2.9, "Precision": 100, "Esquive": 15 }
-        },
-        {
-            "id": "flame_hydra",
-            "nom": "Flame Hydra",
-            "level": 33,
-            "famille": "Beast",
-            "isBoss": false,
-            "palier": 11,
-            "stats": { "PV": 2300, "AttMin": 184, "AttMax": 211, "CritPct": 10, "CritDmg": 150, "Armure": 900, "Vitesse": 2.7, "Precision": 100, "Esquive": 12 }
-        },
-        {
-            "id": "brimstone_devil",
-            "nom": "Brimstone Devil",
-            "level": 33,
-            "famille": "Demon",
-            "isBoss": false,
-            "palier": 11,
-            "stats": { "PV": 1900, "AttMin": 193, "AttMax": 220, "CritPct": 18, "CritDmg": 170, "Armure": 750, "Vitesse": 2.2, "Precision": 105, "Esquive": 22 }
-        },
-        {
-            "id": "ash_harpy",
-            "nom": "Ash Harpy",
-            "level": 33,
-            "famille": "Beast",
-            "isBoss": false,
-            "palier": 11,
-            "stats": { "PV": 1800, "AttMin": 188, "AttMax": 216, "CritPct": 20, "CritDmg": 180, "Armure": 700, "Vitesse": 2, "Precision": 110, "Esquive": 28 }
-        },
-        {
-            "id": "colossal_carnivorous_plant",
-            "nom": "Colossal Carnivorous Plant",
-            "level": 34,
-            "famille": "Plant",
-            "isBoss": false,
-            "palier": 12,
-            "stats": { "PV": 3280, "AttMin": 202, "AttMax": 230, "CritPct": 8, "CritDmg": 150, "Armure": 1200, "Vitesse": 3.6, "Precision": 100, "Esquive": 8 }
-        },
-        {
-            "id": "verdant_wyrm",
-            "nom": "Verdant Wyrm",
-            "level": 35,
-            "famille": "Dragonkin",
-            "isBoss": false,
-            "palier": 12,
-            "stats": { "PV": 2870, "AttMin": 211, "AttMax": 239, "CritPct": 12, "CritDmg": 160, "Armure": 1000, "Vitesse": 2.9, "Precision": 105, "Esquive": 15 }
-        },
-        {
-            "id": "elf_ranger",
-            "nom": "Elf Ranger",
-            "level": 36,
-            "famille": "Humanoid",
-            "isBoss": false,
-            "palier": 12,
-            "stats": { "PV": 2300, "AttMin": 230, "AttMax": 257, "CritPct": 25, "CritDmg": 180, "Armure": 800, "Vitesse": 2, "Precision": 120, "Esquive": 30 }
-        },
-        {
-            "id": "satyr_trickster",
-            "nom": "Satyr Trickster",
-            "level": 36,
-            "famille": "Fey",
-            "isBoss": false,
-            "palier": 12,
-            "stats": { "PV": 2200, "AttMin": 220, "AttMax": 248, "CritPct": 22, "CritDmg": 175, "Armure": 750, "Vitesse": 1.8, "Precision": 115, "Esquive": 35 }
-        },
-        {
-            "id": "emerald_golem",
-            "nom": "Emerald Golem",
-            "level": 36,
-            "famille": "Construct",
-            "isBoss": false,
-            "palier": 12,
-            "stats": { "PV": 3700, "AttMin": 211, "AttMax": 239, "CritPct": 5, "CritDmg": 150, "Armure": 1500, "Vitesse": 4, "Precision": 100, "Esquive": 5 },
-            "componentLoot": [
-                { "id": "primordial_earth", "chance": 0.15, "quantity": 1 }
-            ]
-        },
-        {
-            "id": "dread_lich",
-            "nom": "Dread Lich",
-            "level": 37,
-            "famille": "Undead",
-            "isBoss": false,
-            "palier": 13,
-            "stats": { "PV": 3100, "AttMin": 276, "AttMax": 312, "CritPct": 15, "CritDmg": 180, "Armure": 1100, "Vitesse": 2.5, "Precision": 110, "Esquive": 20 }
-        },
-        {
-            "id": "elder_thing",
-            "nom": "Elder Thing",
-            "level": 38,
-            "famille": "Aberration",
-            "isBoss": false,
-            "palier": 13,
-            "stats": { "PV": 4100, "AttMin": 257, "AttMax": 294, "CritPct": 10, "CritDmg": 160, "Armure": 1300, "Vitesse": 3.3, "Precision": 105, "Esquive": 10 }
-        },
-        {
-            "id": "void_reaver",
-            "nom": "Void Reaver",
-            "level": 39,
-            "famille": "Demon",
-            "isBoss": false,
-            "palier": 13,
-            "stats": { "PV": 3700, "AttMin": 294, "AttMax": 331, "CritPct": 12, "CritDmg": 170, "Armure": 1200, "Vitesse": 2.8, "Precision": 115, "Esquive": 18 }
-        },
-        {
-            "id": "bone_collector",
-            "nom": "Bone Collector",
-            "level": 39,
-            "famille": "Construct",
-            "isBoss": false,
-            "palier": 13,
-            "stats": { "PV": 4500, "AttMin": 266, "AttMax": 303, "CritPct": 8, "CritDmg": 150, "Armure": 1600, "Vitesse": 3.7, "Precision": 100, "Esquive": 8 }
-        },
-        {
-            "id": "soul_eater",
-            "nom": "Soul Eater",
-            "level": 39,
-            "famille": "Aberration",
-            "isBoss": false,
-            "palier": 13,
-            "stats": { "PV": 3450, "AttMin": 303, "AttMax": 340, "CritPct": 18, "CritDmg": 190, "Armure": 1000, "Vitesse": 2.3, "Precision": 120, "Esquive": 25 }
-        },
-        {
-            "id": "tomb_guardian",
-            "nom": "Tomb Guardian",
-            "level": 39,
-            "famille": "Construct",
-            "isBoss": false,
-            "palier": 13,
-            "stats": { "PV": 5000, "AttMin": 276, "AttMax": 322, "CritPct": 5, "CritDmg": 150, "Armure": 2000, "Vitesse": 4.2, "Precision": 100, "Esquive": 5 }
-        },
-        {
-            "id": "ancient_frost_wyrm",
-            "nom": "Ancient Frost Wyrm",
-            "level": 40,
-            "famille": "Dragonkin",
-            "isBoss": true,
-            "palier": 14,
-            "stats": { "PV": 12000, "AttMin": 360, "AttMax": 405, "CritPct": 15, "CritDmg": 180, "Armure": 2500, "Vitesse": 3, "Precision": 120, "Esquive": 15 },
-            "abilities": [{"id": "deep_freeze", "name": "Gelure profonde", "cooldown": 20, "chance": 0.3, "effects": [{ "type": "debuff", "debuffType": "cc", "id": "deep_freeze_stun", "name": "Gelé", "duration": 4, "ccType": "stun" }] }]
-        },
-        {
-            "id": "ice_titan",
-            "nom": "Ice Titan",
-            "level": 41,
-            "famille": "Giant",
-            "isBoss": false,
-            "palier": 14,
-            "stats": { "PV": 6400, "AttMin": 315, "AttMax": 360, "CritPct": 10, "CritDmg": 150, "Armure": 2200, "Vitesse": 3.8, "Precision": 110, "Esquive": 10 }
-        },
-        {
-            "id": "avalanche_spirit",
-            "nom": "Avalanche Spirit",
-            "level": 42,
-            "famille": "Elemental",
-            "isBoss": false,
-            "palier": 14,
-            "stats": { "PV": 5200, "AttMin": 342, "AttMax": 387, "CritPct": 12, "CritDmg": 160, "Armure": 1800, "Vitesse": 2.7, "Precision": 115, "Esquive": 20 }
-        },
-        {
-            "id": "yeti_patriarch",
-            "nom": "Yeti Patriarch",
-            "level": 42,
-            "famille": "Giant",
-            "isBoss": false,
-            "palier": 14,
-            "stats": { "PV": 7200, "AttMin": 324, "AttMax": 369, "CritPct": 8, "CritDmg": 150, "Armure": 2400, "Vitesse": 4, "Precision": 105, "Esquive": 8 }
-        },
-        {
-            "id": "frost-forged_sentinel",
-            "nom": "Frost-forged Sentinel",
-            "level": 42,
-            "famille": "Construct",
-            "isBoss": false,
-            "palier": 14,
-            "stats": { "PV": 8000, "AttMin": 306, "AttMax": 351, "CritPct": 5, "CritDmg": 150, "Armure": 3000, "Vitesse": 4.5, "Precision": 100, "Esquive": 5 }
-        },
-        {
-            "id": "seraphim_of_ice",
-            "nom": "Seraphim of Ice",
-            "level": 42,
-            "famille": "Celestial",
-            "isBoss": false,
-            "palier": 14,
-            "stats": { "PV": 5600, "AttMin": 360, "AttMax": 405, "CritPct": 20, "CritDmg": 190, "Armure": 1600, "Vitesse": 2.4, "Precision": 125, "Esquive": 28 }
-        },
-        {
-            "id": "primeval_magma_dragon",
-            "nom": "Primeval Magma Dragon",
-            "level": 43,
-            "famille": "Dragonkin",
-            "isBoss": true,
-            "palier": 15,
-            "stats": { "PV": 14400, "AttMin": 405, "AttMax": 450, "CritPct": 15, "CritDmg": 180, "Armure": 2800, "Vitesse": 3, "Precision": 125, "Esquive": 15 },
-            "abilities": [{"id": "magma_breath", "name": "Souffle de Magma", "cooldown": 20, "chance": 0.5, "effects": [{ "type": "damage", "damageType": "fire", "multiplier": 1.5 }, { "type": "debuff", "debuffType": "vulnerability", "id": "magma_vuln", "name": "Armure fondue", "duration": 10, "damageType": "all", "multiplier": 1.15 }] }]
-        },
-        {
-            "id": "balrog",
-            "nom": "Balrog",
-            "level": 44,
-            "famille": "Demon",
-            "isBoss": false,
-            "palier": 15,
-            "stats": { "PV": 9600, "AttMin": 450, "AttMax": 495, "CritPct": 20, "CritDmg": 200, "Armure": 2500, "Vitesse": 2.6, "Precision": 130, "Esquive": 20 }
-        },
-        {
-            "id": "phoenix",
-            "nom": "Phoenix",
-            "level": 45,
-            "famille": "Celestial",
-            "isBoss": false,
-            "palier": 15,
-            "stats": { "PV": 8000, "AttMin": 432, "AttMax": 477, "CritPct": 18, "CritDmg": 190, "Armure": 2200, "Vitesse": 2.2, "Precision": 135, "Esquive": 30 }
-        },
-        {
-            "id": "efreeti_sultan",
-            "nom": "Efreeti Sultan",
-            "level": 45,
-            "famille": "Elemental",
-            "isBoss": false,
-            "palier": 15,
-            "stats": { "PV": 10400, "AttMin": 414, "AttMax": 459, "CritPct": 12, "CritDmg": 160, "Armure": 3000, "Vitesse": 3.2, "Precision": 120, "Esquive": 12 }
-        },
-        {
-            "id": "volcanic_titan",
-            "nom": "Volcanic Titan",
-            "level": 45,
-            "famille": "Giant",
-            "isBoss": false,
-            "palier": 15,
-            "stats": { "PV": 12000, "AttMin": 396, "AttMax": 441, "CritPct": 10, "CritDmg": 150, "Armure": 3500, "Vitesse": 4.2, "Precision": 115, "Esquive": 8 }
-        },
-        {
-            "id": "charred_legionnaire",
-            "nom": "Charred Legionnaire",
-            "level": 45,
-            "famille": "Undead",
-            "isBoss": false,
-            "palier": 15,
-            "stats": { "PV": 8800, "AttMin": 423, "AttMax": 468, "CritPct": 15, "CritDmg": 170, "Armure": 2600, "Vitesse": 2.9, "Precision": 125, "Esquive": 18 }
-        },
-        {
-            "id": "world_ash_treant",
-            "nom": "World Ash Treant",
-            "level": 46,
-            "famille": "Plant",
-            "isBoss": true,
-            "palier": 16,
-            "stats": { "PV": 20000, "AttMin": 495, "AttMax": 540, "CritPct": 10, "CritDmg": 160, "Armure": 4000, "Vitesse": 4.5, "Precision": 130, "Esquive": 10 },
-            "abilities": [{"id": "ashes_of_the_world", "name": "Cendres du Monde", "cooldown": 25, "chance": 0.4, "effects": [{ "type": "buff", "buffType": "stat_modifier", "id": "world_ash_dmg_buff", "name": "Puissance des cendres", "duration": 15, "statMods": [{ "stat": "AttMin", "modifier": "multiplicative", "value": 1.25 }, { "stat": "AttMax", "modifier": "multiplicative", "value": 1.25 }] }, { "type": "debuff", "debuffType": "dot", "id": "world_ash_aura", "name": "Aura de cendres", "duration": 15, "damageType": "fire", "totalDamage": { "source": "base_value", "multiplier": 350 } }] }]
-        },
-        {
-            "id": "gaia_avatar",
-            "nom": "Gaia's Avatar",
-            "level": 47,
-            "famille": "Elemental",
-            "isBoss": false,
-            "palier": 16,
-            "stats": { "PV": 16000, "AttMin": 540, "AttMax": 585, "CritPct": 15, "CritDmg": 180, "Armure": 3500, "Vitesse": 3.2, "Precision": 140, "Esquive": 20 }
-        },
-        {
-            "id": "archdruid_of_the_fang",
-            "nom": "Archdruid of the Fang",
-            "level": 48,
-            "famille": "Humanoid",
-            "isBoss": false,
-            "palier": 16,
-            "stats": { "PV": 14400, "AttMin": 585, "AttMax": 630, "CritPct": 25, "CritDmg": 200, "Armure": 3000, "Vitesse": 2.5, "Precision": 150, "Esquive": 30 }
-        },
-        {
-            "id": "fenrir's_chosen",
-            "nom": "Fenrir's Chosen",
-            "level": 48,
-            "famille": "Beast",
-            "isBoss": false,
-            "palier": 16,
-            "stats": { "PV": 15200, "AttMin": 612, "AttMax": 657, "CritPct": 30, "CritDmg": 220, "Armure": 2800, "Vitesse": 2, "Precision": 160, "Esquive": 35 }
-        },
-        {
-            "id": "fae_king",
-            "nom": "Fae King",
-            "level": 48,
-            "famille": "Fey",
-            "isBoss": false,
-            "palier": 16,
-            "stats": { "PV": 13600, "AttMin": 630, "AttMax": 675, "CritPct": 28, "CritDmg": 210, "Armure": 2600, "Vitesse": 1.8, "Precision": 170, "Esquive": 40 }
-        },
-        {
-            "id": "living_world-tree",
-            "nom": "Living World-Tree",
-            "level": 48,
-            "famille": "Construct",
-            "isBoss": false,
-            "palier": 16,
-            "stats": { "PV": 24000, "AttMin": 522, "AttMax": 567, "CritPct": 8, "CritDmg": 150, "Armure": 5000, "Vitesse": 5, "Precision": 120, "Esquive": 5 }
-        },
-        {
-            "id": "herald_of_cthulhu",
-            "nom": "Herald of Cthulhu",
-            "level": 49,
-            "famille": "Aberration",
-            "isBoss": true,
-            "palier": 17,
-            "stats": { "PV": 32000, "AttMin": 720, "AttMax": 810, "CritPct": 20, "CritDmg": 200, "Armure": 4500, "Vitesse": 2.8, "Precision": 160, "Esquive": 25 },
-            "abilities": [{"id": "touch_of_the_void", "name": "Toucher du Vide", "cooldown": 18, "chance": 0.5, "effects": [{ "type": "damage", "damageType": "shadow", "multiplier": 1.4 }, { "type": "debuff", "debuffType": "stat_modifier", "id": "insanity_debuff", "name": "Folie", "duration": 12, "statMods": [{ "stat": "Precision", "modifier": "multiplicative", "value": 0.75 }, { "stat": "Esquive", "modifier": "multiplicative", "value": 0.75 }] }] }]
-        },
-        {
-            "id": "archlich_of_nar'thalas",
-            "nom": "Archlich of Nar'thalas",
-            "level": 50,
-            "famille": "Undead",
-            "isBoss": false,
-            "palier": 17,
-            "stats": { "PV": 28000, "AttMin": 810, "AttMax": 900, "CritPct": 25, "CritDmg": 220, "Armure": 4000, "Vitesse": 2.4, "Precision": 170, "Esquive": 30 }
-        },
-        {
-            "id": "gibbering_mouther",
-            "nom": "Gibbering Mouther",
-            "level": 50,
-            "famille": "Aberration",
-            "isBoss": false,
-            "palier": 17,
-            "stats": { "PV": 30400, "AttMin": 765, "AttMax": 855, "CritPct": 18, "CritDmg": 190, "Armure": 4200, "Vitesse": 3, "Precision": 150, "Esquive": 20 }
-        },
-        {
-            "id": "void_leviathan",
-            "nom": "Void Leviathan",
-            "level": 50,
-            "famille": "Aberration",
-            "isBoss": false,
-            "palier": 17,
-            "stats": { "PV": 40000, "AttMin": 738, "AttMax": 828, "CritPct": 12, "CritDmg": 170, "Armure": 6000, "Vitesse": 4, "Precision": 140, "Esquive": 10 }
-        },
-        {
-            "id": "ethereal_devourer",
-            "nom": "Ethereal Devourer",
-            "level": 50,
-            "famille": "Aberration",
-            "isBoss": false,
-            "palier": 17,
-            "stats": { "PV": 28800, "AttMin": 855, "AttMax": 945, "CritPct": 28, "CritDmg": 230, "Armure": 3800, "Vitesse": 2.2, "Precision": 180, "Esquive": 35 }
-        },
-        {
-            "id": "shadow_titan",
-            "nom": "Shadow Titan",
-            "level": 50,
-            "famille": "Giant",
-            "isBoss": false,
-            "palier": 17,
-            "stats": { "PV": 48000, "AttMin": 792, "AttMax": 882, "CritPct": 15, "CritDmg": 180, "Armure": 7000, "Vitesse": 4.5, "Precision": 150, "Esquive": 12 }
-        },
-        {
-            "id": "death_knight_champion",
-            "nom": "Death Knight Champion",
-            "level": 50,
-            "famille": "Undead",
-            "isBoss": false,
-            "palier": 17,
-            "stats": { "PV": 36000, "AttMin": 828, "AttMax": 918, "CritPct": 22, "CritDmg": 210, "Armure": 5500, "Vitesse": 2.9, "Precision": 160, "Esquive": 22 }
-        },
-        {
-            "id": "bat_matriarch",
-            "nom": "Matriarche des Cavernes",
-            "level": 5,
-            "famille": "Beast",
-            "isBoss": true,
-            "palier": 1,
-            "stats": { "PV": 200, "AttMin": 15, "AttMax": 22, "CritPct": 12, "CritDmg": 150, "Armure": 40, "Vitesse": 2.0, "Precision": 70, "Esquive": 20 },
-            "abilities": [{
-                "id": "piercing_screech", "name": "Cri perçant", "cooldown": 12, "chance": 0.4,
-                "effects": [{ "type": "debuff", "debuffType": "stat_modifier", "id": "screech_armor_down", "name": "Armure brisée", "duration": 8, "statMods": [{ "stat": "Armure", "modifier": "multiplicative", "value": 0.85 }] }]
-            }]
-        },
-        {
-            "id": "yeti_chieftain",
-            "nom": "Chef de Clan Yéti",
-            "level": 8,
-            "famille": "Giant",
-            "isBoss": true,
-            "palier": 2,
-            "stats": { "PV": 600, "AttMin": 25, "AttMax": 35, "CritPct": 8, "CritDmg": 150, "Armure": 150, "Vitesse": 3.2, "Precision": 75, "Esquive": 10 },
-            "abilities": [{
-                "id": "ground_slam", "name": "Frappe assommante", "cooldown": 10, "chance": 0.5,
-                "effects": [
-                    { "type": "damage", "damageType": "physical", "multiplier": 1.5 },
-                    { "type": "debuff", "debuffType": "cc", "id": "slam_stun", "name": "Assommé", "duration": 2, "ccType": "stun" }
-                ]
-            }],
-            "specificLootTable": ["axe_of_the_deathbringer", "set_silver_guard_helm", "set_silver_guard_chest"],
-            "componentLoot": [
-                { "id": "frozen_heart", "chance": 0.25, "quantity": 1 }
-            ]
-        },
-        {
-            "id": "inferno_elemental_lord",
-            "nom": "Seigneur Élémentaire des Cendres",
-            "level": 11,
-            "famille": "Elemental",
-            "isBoss": true,
-            "palier": 3,
-            "stats": { "PV": 800, "AttMin": 45, "AttMax": 55, "CritPct": 10, "CritDmg": 150, "Armure": 180, "Vitesse": 2.7, "Precision": 80, "Esquive": 12, "ResElems": { "fire": 40, "ice": -20 } },
-            "abilities": [{
-                "id": "immolation", "name": "Immolation", "cooldown": 12, "chance": 0.5,
-                "effects": [{ "type": "debuff", "debuffType": "dot", "id": "immolation_dot", "name": "Immolation", "duration": 6, "damageType": "fire", "totalDamage": { "source": "base_value", "multiplier": 90 } }]
-            }],
-            "specificLootTable": ["set_arcanist_cowl", "set_arcanist_robe"],
-            "recipeLoot": [
-                { "id": "enchant_superior_fire_resistance", "chance": 0.1, "quantity": 1 }
-            ]
-        },
-        {
-            "id": "ancient_dryad_matriarch",
-            "nom": "Matriarche Dryade Ancienne",
-            "level": 14,
-            "famille": "Fey",
-            "isBoss": true,
-            "palier": 4,
-            "stats": { "PV": 1200, "AttMin": 60, "AttMax": 75, "CritPct": 15, "CritDmg": 160, "Armure": 250, "Vitesse": 2.4, "Precision": 85, "Esquive": 18 },
-            "abilities": [{
-                "id": "barkskin", "name": "Écorcefer", "cooldown": 20, "chance": 0.3,
-                "effects": [{ "type": "buff", "buffType": "stat_modifier", "id": "barkskin_buff", "name": "Écorcefer", "duration": 10, "statMods": [{ "stat": "Armure", "modifier": "multiplicative", "value": 2.0 }] }]
-            }],
-            "specificLootTable": ["set_shadow_shroud_mask", "set_shadow_shroud_tunic"]
-        },
-        {
-            "id": "void_cultist_leader",
-            "nom": "Chef de Culte du Vide",
-            "level": 17,
-            "famille": "Humanoid",
-            "isBoss": true,
-            "palier": 5,
-            "stats": { "PV": 1800, "AttMin": 70, "AttMax": 85, "CritPct": 12, "CritDmg": 150, "Armure": 350, "Vitesse": 2.8, "Precision": 90, "Esquive": 14 },
-            "abilities": [{
-                "id": "void_bolt", "name": "Trait du Vide", "cooldown": 8, "chance": 0.6,
-                "effects": [{ "type": "damage", "damageType": "shadow", "multiplier": 1.2 }]
-            }]
-        },
-        {
-            "id": "void_priest",
-            "nom": "Prêtre du Vide",
-            "level": 17,
-            "famille": "Humanoid",
-            "isBoss": true,
-            "palier": 5,
-            "stats": { "PV": 1900, "AttMin": 75, "AttMax": 90, "CritPct": 14, "CritDmg": 160, "Armure": 380, "Vitesse": 2.6, "Precision": 92, "Esquive": 16 },
-            "abilities": [{
-                "id": "mind_flay", "name": "Fouet mental", "cooldown": 10, "chance": 0.5,
-                "effects": [{ "type": "debuff", "debuffType": "dot", "id": "mind_flay_dot", "name": "Fouet mental", "duration": 9, "damageType": "shadow", "totalDamage": { "source": "base_value", "multiplier": 120 } }]
-            }]
-        },
-        {
-            "id": "icebound_warlord",
-            "nom": "Seigneur de Guerre Englacé",
-            "level": 20,
-            "famille": "Humanoid",
-            "isBoss": true,
-            "palier": 6,
-            "stats": { "PV": 2125, "AttMin": 90, "AttMax": 109, "CritPct": 15, "CritDmg": 150, "Armure": 500, "Vitesse": 3.2, "Precision": 95, "Esquive": 10 },
-            "abilities": [{"id": "shattering_strike", "name": "Frappe fracassante", "cooldown": 12, "chance": 0.4, "effects": [{ "type": "damage", "damageType": "physical", "multiplier": 1.4 }, { "type": "debuff", "debuffType": "stat_modifier", "id": "shattering_armor_down", "name": "Armure fracassée", "duration": 10, "statMods": [{ "stat": "Armure", "modifier": "multiplicative", "value": 0.80 }] }] }],
-            "specificLootTable": ["rep_silver_vanguard_helm", "rep_silver_vanguard_greataxe"]
-        },
-        {
-            "id": "fire_giant_champion",
-            "nom": "Champion Géant de Feu",
-            "level": 23,
-            "famille": "Giant",
-            "isBoss": true,
-            "palier": 7,
-            "stats": { "PV": 2975, "AttMin": 114, "AttMax": 133, "CritPct": 10, "CritDmg": 150, "Armure": 700, "Vitesse": 3.4, "Precision": 100, "Esquive": 9 },
-            "abilities": [{"id": "scorching_smash", "name": "Fracas incandescent", "cooldown": 10, "chance": 0.5, "effects": [{ "type": "damage", "damageType": "fire", "multiplier": 1.6 }] }],
-            "specificLootTable": ["rep_magma_callers_cowl", "rep_magma_callers_staff"]
-        },
-        {
-            "id": "guardian_of_the_grove",
-            "nom": "Gardien du Bosquet",
-            "level": 26,
-            "famille": "Fey",
-            "isBoss": true,
-            "palier": 8,
-            "stats": { "PV": 3825, "AttMin": 142, "AttMax": 171, "CritPct": 18, "CritDmg": 160, "Armure": 800, "Vitesse": 2.6, "Precision": 105, "Esquive": 20 },
-            "abilities": [{"id": "natures_grasp", "name": "Poigne de la nature", "cooldown": 15, "chance": 0.4, "effects": [{ "type": "debuff", "debuffType": "stat_modifier", "id": "grasp_slow", "name": "Ralenti", "duration": 8, "statMods": [{ "stat": "Vitesse", "modifier": "multiplicative", "value": 1.40 }] }] }],
-            "specificLootTable": ["rep_silent_path_mask", "rep_silent_path_daggers"]
-        },
-        {
-            "id": "spectral_overlord",
-            "nom": "Souverain Spectral",
-            "level": 29,
-            "famille": "Undead",
-            "isBoss": true,
-            "palier": 9,
-            "stats": { "PV": 4675, "AttMin": 180, "AttMax": 209, "CritPct": 22, "CritDmg": 180, "Armure": 900, "Vitesse": 2.0, "Precision": 110, "Esquive": 32 },
-            "abilities": [{"id": "soul_drain", "name": "Drain d'âme", "cooldown": 12, "chance": 0.5, "effects": [{ "type": "debuff", "debuffType": "dot", "id": "soul_drain_dot", "name": "Drain d'âme", "duration": 6, "damageType": "shadow", "totalDamage": { "source": "base_value", "multiplier": 150 } }] }],
-            "specificLootTable": ["rep_faithsworn_diadem", "rep_faithsworn_mace"]
-        },
-        {
-            "id": "boreal_crusader",
-            "nom": "Croisé Boréal",
-            "level": 32,
-            "famille": "Humanoid",
-            "isBoss": true,
-            "palier": 10,
-            "stats": { "PV": 5740, "AttMin": 211, "AttMax": 248, "CritPct": 15, "CritDmg": 150, "Armure": 1500, "Vitesse": 3.2, "Precision": 115, "Esquive": 14 },
-            "abilities": [{"id": "crusader_strike", "name": "Frappe du croisé", "cooldown": 8, "chance": 0.6, "effects": [{ "type": "damage", "damageType": "holy", "multiplier": 1.3 }] }]
-        },
-        {
-            "id": "ashwing_matriarch",
-            "nom": "Matriarche Aile-de-Cendre",
-            "level": 35,
-            "famille": "Beast",
-            "isBoss": true,
-            "palier": 11,
-            "stats": { "PV": 6560, "AttMin": 257, "AttMax": 294, "CritPct": 25, "CritDmg": 180, "Armure": 1600, "Vitesse": 2.2, "Precision": 120, "Esquive": 30 },
-            "abilities": [{"id": "wing_buffet", "name": "Coup d'aile", "cooldown": 18, "chance": 0.3, "effects": [{ "type": "debuff", "debuffType": "cc", "id": "wing_buffet_stun", "name": "Repoussé", "duration": 2.5, "ccType": "stun" }] }]
-        },
-        {
-            "id": "colossus_of_the_grove",
-            "nom": "Colosse du Bosquet",
-            "level": 38,
-            "famille": "Construct",
-            "isBoss": true,
-            "palier": 12,
-            "stats": { "PV": 9840, "AttMin": 322, "AttMax": 368, "CritPct": 10, "CritDmg": 150, "Armure": 2500, "Vitesse": 4.2, "Precision": 125, "Esquive": 7 },
-            "abilities": [{"id": "overgrowth", "name": "Surcroissance", "cooldown": 15, "chance": 0.4, "effects": [{ "type": "debuff", "debuffType": "stat_modifier", "id": "overgrowth_slow", "name": "Enraciné", "duration": 6, "statMods": [{ "stat": "Vitesse", "modifier": "multiplicative", "value": 1.5 }] }, { "type": "debuff", "debuffType": "dot", "id": "overgrowth_dot", "name": "Ronces", "duration": 6, "damageType": "nature", "totalDamage": { "source": "base_value", "multiplier": 180 } }] }]
-        },
-        {
-            "id": "ancient_tomb_protector",
-            "nom": "Protecteur de Tombe Ancien",
-            "level": 41,
-            "famille": "Construct",
-            "isBoss": true,
-            "palier": 13,
-            "stats": { "PV": 12000, "AttMin": 378, "AttMax": 432, "CritPct": 8, "CritDmg": 150, "Armure": 3500, "Vitesse": 4.5, "Precision": 130, "Esquive": 6 },
-            "abilities": [{"id": "stone_form", "name": "Forme de pierre", "cooldown": 25, "chance": 0.25, "effects": [{ "type": "buff", "buffType": "stat_modifier", "id": "stone_form_buff", "name": "Forme de pierre", "duration": 8, "statMods": [{ "stat": "Armure", "modifier": "multiplicative", "value": 3.0 }] }] }]
-        },
-        {
-            "id": "garak_frostfang",
-            "nom": "Garak, the Frostfang",
-            "level": 22,
-            "famille": "Dragonkin",
-            "isBoss": true,
-            "palier": 7,
-            "stats": { "PV": 3500, "AttMin": 120, "AttMax": 150, "CritPct": 15, "CritDmg": 160, "Armure": 800, "Vitesse": 3.0, "Precision": 100, "Esquive": 12, "ResElems": { "ice": 50, "fire": -25 } },
-            "abilities": [{"id": "frost_breath", "name": "Souffle de Givre", "cooldown": 12, "chance": 0.5, "effects": [{ "type": "damage", "damageType": "ice", "multiplier": 1.5 }, { "type": "debuff", "debuffType": "stat_modifier", "id": "frost_breath_slow", "name": "Souffle glacial", "duration": 8, "statMods": [{ "stat": "Vitesse", "modifier": "multiplicative", "value": 1.35 }] }] }],
-            "specificLootTable": ["garaks_icy_maw", "frostfang_bite"]
-        },
-        {
-            "id": "goblin_scout_heroic",
-            "nom": "Gobelin Éclaireur Héroïque",
-            "level": 51,
-            "famille": "Goblinoid",
-            "isBoss": false,
-            "palier": 11,
-            "stats": { "PV": 300, "AttMin": 25, "AttMax": 40, "CritPct": 10, "CritDmg": 175, "Armure": 50, "Vitesse": 2.5, "Precision": 100, "Esquive": 15 }
-        },
-        {
-            "id": "giant_rat_heroic",
-            "nom": "Rat Géant Héroïque",
-            "level": 51,
-            "famille": "Beast",
-            "isBoss": false,
-            "palier": 11,
-            "stats": { "PV": 250, "AttMin": 20, "AttMax": 35, "CritPct": 8, "CritDmg": 175, "Armure": 25, "Vitesse": 2.2, "Precision": 95, "Esquive": 18 }
-        },
-        {
-            "id": "kobold_miner_supervisor_heroic",
-            "nom": "Superviseur Mineur Kobold Héroïque",
-            "famille": "Humanoid",
-            "level": 53,
-            "isBoss": true,
-            "palier": 11,
-            "stats": { "PV": 1500, "AttMin": 60, "AttMax": 90, "CritPct": 15, "CritDmg": 175, "Armure": 250, "Vitesse": 2.5, "Precision": 115, "Esquive": 15 },
-            "abilities": [{
-                "id": "get_back_to_work", "name": "Au travail !", "cooldown": 15, "chance": 0.4,
-                "effects": [{ "type": "debuff", "debuffType": "cc", "id": "supervisor_stun", "name": "Intimidation", "duration": 2, "ccType": "stun" }]
-            }]
-        },
-        {
-            "id": "kobold_miner_assistant_heroic",
-            "nom": "Assistant Mineur Kobold Héroïque",
-            "level": 52,
-            "famille": "Humanoid",
-            "isBoss": false,
-            "palier": 11,
-            "stats": { "PV": 400, "AttMin": 30, "AttMax": 45, "CritPct": 10, "CritDmg": 175, "Armure": 100, "Vitesse": 2.8, "Precision": 105, "Esquive": 13 }
-        },
-        {
-            "id": "cave_bat_heroic",
-            "nom": "Chauve-souris des Cavernes Héroïque",
-            "level": 53,
-            "famille": "Beast",
-            "isBoss": false,
-            "palier": 11,
-            "stats": { "PV": 350, "AttMin": 35, "AttMax": 50, "CritPct": 13, "CritDmg": 175, "Armure": 50, "Vitesse": 1.8, "Precision": 110, "Esquive": 25 },
-            "questItemId": "bat_fang_heroic"
-        },
-        {
-            "id": "bat_matriarch_heroic",
-            "nom": "Matriarche des Cavernes Héroïque",
-            "level": 55,
-            "famille": "Beast",
-            "isBoss": true,
-            "palier": 11,
-            "stats": { "PV": 2000, "AttMin": 75, "AttMax": 110, "CritPct": 17, "CritDmg": 175, "Armure": 200, "Vitesse": 2.0, "Precision": 120, "Esquive": 30 },
-            "abilities": [{
-                "id": "sonic_screech_heroic", "name": "Cri Sonique", "cooldown": 12, "chance": 0.5,
-                "effects": [
-                    { "type": "debuff", "debuffType": "stat_modifier", "id": "screech_armor_down_heroic", "name": "Armure brisée (H)", "duration": 10, "statMods": [{ "stat": "Armure", "modifier": "multiplicative", "value": 0.75 }] },
-                    { "type": "debuff", "debuffType": "stat_modifier", "id": "screech_precision_down_heroic", "name": "Désorienté (H)", "duration": 10, "statMods": [{ "stat": "Precision", "modifier": "multiplicative", "value": 0.80 }] }
-                ]
-            }]
-        },
-        {
-            "id": "yeti_chieftain_heroic",
-            "nom": "Chef de Clan Yéti Héroïque",
-            "level": 58,
-            "famille": "Giant",
-            "isBoss": true,
-            "palier": 12,
-            "stats": { "PV": 6000, "AttMin": 125, "AttMax": 175, "CritPct": 13, "CritDmg": 175, "Armure": 750, "Vitesse": 3.2, "Precision": 125, "Esquive": 20 },
-            "abilities": [{
-                "id": "seismic_slam_heroic", "name": "Frappe Sismique", "cooldown": 15, "chance": 0.4,
-                "effects": [
-                    { "type": "damage", "damageType": "physical", "multiplier": 1.8 },
-                    { "type": "debuff", "debuffType": "cc", "id": "slam_stun_heroic", "name": "Assommé (H)", "duration": 3, "ccType": "stun" }
-                ]
-            }]
-        },
-        {
-            "id": "inferno_elemental_lord_heroic",
-            "nom": "Seigneur Élémentaire des Cendres Héroïque",
-            "level": 61,
-            "famille": "Elemental",
-            "isBoss": true,
-            "palier": 13,
-            "stats": { "PV": 8000, "AttMin": 225, "AttMax": 275, "CritPct": 15, "CritDmg": 175, "Armure": 900, "Vitesse": 2.7, "Precision": 130, "Esquive": 22 },
-            "abilities": [{
-                "id": "firestorm_heroic", "name": "Tempête de Feu", "cooldown": 15, "chance": 0.5,
-                "effects": [
-                    { "type": "damage", "damageType": "fire", "multiplier": 1.2 },
-                    { "type": "debuff", "debuffType": "dot", "id": "immolation_dot_heroic", "name": "Immolation (H)", "duration": 9, "damageType": "fire", "totalDamage": { "source": "base_value", "multiplier": 200 } }
-                ]
-            }]
-        },
-        {
-            "id": "ancient_dryad_matriarch_heroic",
-            "nom": "Matriarche Dryade Ancienne Héroïque",
-            "level": 64,
-            "famille": "Fey",
-            "isBoss": true,
-            "palier": 14,
-            "stats": { "PV": 12000, "AttMin": 300, "AttMax": 375, "CritPct": 20, "CritDmg": 185, "Armure": 1250, "Vitesse": 2.4, "Precision": 135, "Esquive": 28 },
-            "abilities": [{
-                "id": "thornbark_heroic", "name": "Écorce d'Épines", "cooldown": 20, "chance": 0.4,
-                "effects": [
-                    { "type": "buff", "buffType": "stat_modifier", "id": "barkskin_buff_heroic", "name": "Écorcefer (H)", "duration": 12, "statMods": [{ "stat": "Armure", "modifier": "multiplicative", "value": 2.50 }] },
-                    { "type": "buff", "buffType": "damage_reflection", "id": "thorns_buff_heroic", "name": "Épines (H)", "duration": 12, "reflectionValue": 0.30 }
-                ]
-            }]
-        },
-        {
-            "id": "void_cultist_leader_heroic",
-            "nom": "Chef de Culte du Vide Héroïque",
-            "level": 67,
-            "famille": "Humanoid",
-            "isBoss": true,
-            "palier": 15,
-            "stats": { "PV": 18000, "AttMin": 350, "AttMax": 425, "CritPct": 17, "CritDmg": 175, "Armure": 1750, "Vitesse": 2.8, "Precision": 140, "Esquive": 24 },
-            "abilities": [{
-                "id": "voids_embrace_heroic", "name": "Étreinte du Vide", "cooldown": 12, "chance": 0.6,
-                "effects": [
-                    { "type": "debuff", "debuffType": "vulnerability", "id": "shadow_vuln_heroic", "name": "Vulnérabilité à l'Ombre (H)", "duration": 8, "damageType": "shadow", "multiplier": 1.25 },
-                    { "type": "damage", "damageType": "shadow", "multiplier": 1.3 }
-                ]
-            }]
-        },
-        {
-            "id": "void_priest_heroic",
-            "nom": "Prêtre du Vide Héroïque",
-            "level": 67,
-            "famille": "Humanoid",
-            "isBoss": true,
-            "palier": 15,
-            "stats": { "PV": 19000, "AttMin": 375, "AttMax": 450, "CritPct": 19, "CritDmg": 185, "Armure": 1900, "Vitesse": 2.6, "Precision": 142, "Esquive": 26 },
-            "abilities": [{
-                "id": "eternal_torment_heroic", "name": "Tourment Éternel", "cooldown": 15, "chance": 0.5,
-                "effects": [
-                    { "type": "debuff", "debuffType": "dot", "id": "mind_flay_dot_heroic", "name": "Fouet mental (H)", "duration": 9, "damageType": "shadow", "totalDamage": { "source": "base_value", "multiplier": 250 } },
-                    { "type": "debuff", "debuffType": "stat_modifier", "id": "power_drain_heroic", "name": "Puissance drainée (H)", "duration": 9, "statMods": [
-                        { "stat": "AttMin", "modifier": "multiplicative", "value": 0.85 },
-                        { "stat": "AttMax", "modifier": "multiplicative", "value": 0.85 }
-                    ]}
-                ]
-            }]
-        },
-        {
-            "id": "icebound_warlord_heroic",
-            "nom": "Seigneur de Guerre Englacé Héroïque",
-            "level": 70,
-            "famille": "Humanoid",
-            "isBoss": true,
-            "palier": 16,
-            "stats": { "PV": 25000, "AttMin": 475, "AttMax": 575, "CritPct": 20, "CritDmg": 175, "Armure": 2500, "Vitesse": 3.2, "Precision": 145, "Esquive": 20 },
-            "abilities": [{
-                "id": "glacial_annihilation_heroic", "name": "Anéantissement Glacial", "cooldown": 12, "chance": 0.5,
-                "effects": [
-                    { "type": "damage", "damageType": "physical", "multiplier": 0.75 },
-                    { "type": "damage", "damageType": "ice", "multiplier": 0.75 },
-                    { "type": "debuff", "debuffType": "stat_modifier", "id": "shattering_armor_down_heroic", "name": "Armure fracassée (H)", "duration": 12, "statMods": [{ "stat": "Armure", "modifier": "multiplicative", "value": 0.65 }] }
-                ]
-            }]
-        },
-        {
-            "id": "fire_giant_champion_heroic",
-            "nom": "Champion Géant de Feu Héroïque",
-            "level": 73,
-            "famille": "Giant",
-            "isBoss": true,
-            "palier": 17,
-            "stats": { "PV": 35000, "AttMin": 600, "AttMax": 700, "CritPct": 15, "CritDmg": 175, "Armure": 3500, "Vitesse": 3.4, "Precision": 150, "Esquive": 19 },
-            "abilities": [{
-                "id": "ashen_mark_heroic", "name": "Marque Cendrée", "cooldown": 16, "chance": 0.4,
-                "effects": [
-                    { "type": "damage", "damageType": "fire", "multiplier": 1.8 },
-                    { "type": "debuff", "debuffType": "healing_received_modifier", "id": "mortal_wound_heroic", "name": "Marque Cendrée (H)", "duration": 10, "multiplier": 0.50 }
-                ]
-            }]
-        },
-        {
-            "id": "guardian_of_the_grove_heroic",
-            "nom": "Gardien du Bosquet Héroïque",
-            "level": 76,
-            "famille": "Fey",
-            "isBoss": true,
-            "palier": 18,
-            "stats": { "PV": 45000, "AttMin": 750, "AttMax": 900, "CritPct": 23, "CritDmg": 185, "Armure": 4000, "Vitesse": 2.6, "Precision": 155, "Esquive": 30 },
-            "abilities": [{"id": "primordial_grasp_heroic", "name": "Emprise Primordiale", "cooldown": 18, "chance": 0.4, "effects": [{ "type": "debuff", "debuffType": "cc", "id": "grasp_root_heroic", "name": "Enraciné (H)", "duration": 4, "ccType": "stun" }, { "type": "debuff", "debuffType": "dot", "id": "grasp_dot_heroic", "name": "Ronces (H)", "duration": 4, "damageType": "nature", "totalDamage": { "source": "base_value", "multiplier": 300 } }] }]
-        },
-        {
-            "id": "spectral_overlord_heroic",
-            "nom": "Souverain Spectral Héroïque",
-            "level": 79,
-            "famille": "Undead",
-            "isBoss": true,
-            "palier": 19,
-            "stats": { "PV": 55000, "AttMin": 950, "AttMax": 1100, "CritPct": 27, "CritDmg": 205, "Armure": 4500, "Vitesse": 2.0, "Precision": 160, "Esquive": 42 },
-            "abilities": [{"id": "feast_of_souls_heroic", "name": "Festin d'Âmes", "cooldown": 20, "chance": 0.5, "effects": [{ "type": "debuff", "debuffType": "dot", "id": "soul_drain_dot_heroic", "name": "Drain d'âme (H)", "duration": 8, "damageType": "shadow", "totalDamage": { "source": "base_value", "multiplier": 400 } }, { "type": "buff", "buffType": "hot", "id": "soul_feast_hot_heroic", "name": "Festin (H)", "duration": 8, "totalHeal": { "source": "max_health_percentage", "percentage": 0.05 } }] }]
-        },
-        {
-            "id": "boreal_crusader_heroic",
-            "nom": "Croisé Boréal Héroïque",
-            "level": 82,
-            "famille": "Humanoid",
-            "isBoss": true,
-            "palier": 20,
-            "stats": { "PV": 70000, "AttMin": 1150, "AttMax": 1350, "CritPct": 20, "CritDmg": 175, "Armure": 7500, "Vitesse": 3.2, "Precision": 165, "Esquive": 24 },
-            "abilities": [{"id": "holy_judgment_heroic", "name": "Jugement Sacré", "cooldown": 15, "chance": 0.5, "effects": [{ "type": "damage", "damageType": "holy", "multiplier": 1.6 }, { "type": "buff", "buffType": "stat_modifier", "id": "judgment_buff_heroic", "name": "Jugement (H)", "duration": 10, "statMods": [{ "stat": "Vitesse", "modifier": "multiplicative_add", "value": -0.20 }, { "stat": "Precision", "modifier": "multiplicative", "value": 1.20 }] }] }]
-        },
-        {
-            "id": "ashwing_matriarch_heroic",
-            "nom": "Matriarche Aile-de-Cendre Héroïque",
-            "level": 85,
-            "famille": "Beast",
-            "isBoss": true,
-            "palier": 21,
-            "stats": { "PV": 80000, "AttMin": 1400, "AttMax": 1600, "CritPct": 30, "CritDmg": 205, "Armure": 8000, "Vitesse": 2.2, "Precision": 170, "Esquive": 40 },
-            "abilities": [{"id": "ashen_tempest_heroic", "name": "Tempête de Cendres", "cooldown": 18, "chance": 0.4, "effects": [{ "type": "damage", "damageType": "physical", "multiplier": 1.5 }, { "type": "debuff", "debuffType": "stat_modifier", "id": "tempest_debuff_heroic", "name": "Aveuglé (H)", "duration": 8, "statMods": [{ "stat": "Precision", "modifier": "multiplicative", "value": 0.70 }, { "stat": "CritPct", "modifier": "multiplicative", "value": 0.70 }] }] }]
-        },
-        {
-            "id": "colossus_of_the_grove_heroic",
-            "nom": "Colosse du Bosquet Héroïque",
-            "level": 88,
-            "famille": "Construct",
-            "isBoss": true,
-            "palier": 22,
-            "stats": { "PV": 120000, "AttMin": 1750, "AttMax": 2000, "CritPct": 15, "CritDmg": 175, "Armure": 12500, "Vitesse": 4.2, "Precision": 175, "Esquive": 17 },
-            "abilities": [{"id": "colossal_slam_heroic", "name": "Frappe Colossale", "cooldown": 20, "chance": 0.4, "effects": [{ "type": "damage", "damageType": "physical", "multiplier": 2.0 }, { "type": "debuff", "debuffType": "stat_modifier", "id": "colossal_slow_heroic", "name": "Écrasé (H)", "duration": 10, "statMods": [{ "stat": "Vitesse", "modifier": "multiplicative", "value": 1.50 }] }] }]
-        },
-        {
-            "id": "ancient_tomb_protector_heroic",
-            "nom": "Protecteur de Tombe Ancien Héroïque",
-            "level": 91,
-            "famille": "Construct",
-            "isBoss": true,
-            "palier": 23,
-            "stats": { "PV": 150000, "AttMin": 2100, "AttMax": 2400, "CritPct": 13, "CritDmg": 175, "Armure": 17500, "Vitesse": 4.5, "Precision": 180, "Esquive": 16 },
-            "abilities": [{"id": "immutable_form_heroic", "name": "Forme Immuable", "cooldown": 30, "chance": 0.3, "effects": [{ "type": "buff", "buffType": "stat_modifier", "id": "stone_form_buff_heroic", "name": "Forme de pierre (H)", "duration": 10, "statMods": [{ "stat": "Armure", "modifier": "multiplicative", "value": 4.0 }] }, { "type": "buff", "buffType": "hot", "id": "stone_regen_heroic", "name": "Régénération (H)", "duration": 10, "totalHeal": { "source": "max_health_percentage", "percentage": 0.15 } }] }]
+  "monsters": [
+    {
+      "id": "goblin_scout",
+      "nom": "Goblin Scout",
+      "level": 1,
+      "famille": "Goblinoid",
+      "isBoss": false,
+      "palier": 1,
+      "stats": {
+        "PV": 30,
+        "AttMin": 5,
+        "AttMax": 8,
+        "CritPct": 5,
+        "CritDmg": 150,
+        "Armure": 10,
+        "Vitesse": 2.5,
+        "Precision": 50,
+        "Esquive": 5
+      }
+    },
+    {
+      "id": "giant_rat",
+      "nom": "Giant Rat",
+      "level": 1,
+      "famille": "Beast",
+      "isBoss": false,
+      "palier": 1,
+      "stats": {
+        "PV": 25,
+        "AttMin": 4,
+        "AttMax": 7,
+        "CritPct": 3,
+        "CritDmg": 150,
+        "Armure": 5,
+        "Vitesse": 2.2,
+        "Precision": 45,
+        "Esquive": 8
+      },
+      "componentLoot": [
+        {
+          "id": "light_leather",
+          "chance": 0.3,
+          "quantity": 1
         }
-    ]
+      ]
+    },
+    {
+      "id": "kobold_miner_supervisor",
+      "nom": "Kobold Miner SUPERVISOR",
+      "famille": "Humanoid",
+      "level": 3,
+      "isBoss": true,
+      "palier": 1,
+      "stats": {
+        "PV": 150,
+        "AttMin": 12,
+        "AttMax": 18,
+        "CritPct": 10,
+        "CritDmg": 150,
+        "Armure": 50,
+        "Vitesse": 2.5,
+        "Precision": 65,
+        "Esquive": 5
+      },
+      "abilities": [
+        {
+          "id": "get_back_to_work",
+          "name": "Au travail !",
+          "cooldown": 15,
+          "chance": 0.3,
+          "effects": [
+            {
+              "type": "debuff",
+              "debuffType": "cc",
+              "id": "supervisor_stun",
+              "name": "Intimidation",
+              "duration": 1.5,
+              "ccType": "stun"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "cinder_lord",
+      "nom": "Cinder Lord",
+      "level": 11,
+      "famille": "Elemental",
+      "isBoss": true,
+      "palier": 3,
+      "stats": {
+        "PV": 850,
+        "AttMin": 48,
+        "AttMax": 58,
+        "CritPct": 12,
+        "CritDmg": 150,
+        "Armure": 170,
+        "Vitesse": 2.6,
+        "Precision": 82,
+        "Esquive": 14,
+        "ResElems": {
+          "fire": 45,
+          "ice": -25
+        }
+      },
+      "abilities": [
+        {
+          "id": "cinder_storm",
+          "name": "Cinder Storm",
+          "cooldown": 15,
+          "chance": 0.5,
+          "effects": [
+            {
+              "type": "debuff",
+              "debuffType": "dot",
+              "id": "cinder_storm_dot",
+              "name": "Cinder Storm",
+              "duration": 9,
+              "damageType": "fire",
+              "totalDamage": {
+                "source": "base_value",
+                "multiplier": 100
+              }
+            }
+          ]
+        }
+      ],
+      "specificLootTable": [
+        "set_arcanist_cowl",
+        "set_arcanist_robe"
+      ],
+      "recipeLoot": [
+        {
+          "id": "enchant_superior_fire_resistance",
+          "chance": 0.1,
+          "quantity": 1
+        }
+      ]
+    },
+    {
+      "id": "cinder_lord_heroic",
+      "nom": "Cinder Lord Heroic",
+      "level": 61,
+      "famille": "Elemental",
+      "isBoss": true,
+      "palier": 13,
+      "stats": {
+        "PV": 8500,
+        "AttMin": 230,
+        "AttMax": 280,
+        "CritPct": 17,
+        "CritDmg": 175,
+        "Armure": 950,
+        "Vitesse": 2.6,
+        "Precision": 132,
+        "Esquive": 24
+      },
+      "abilities": [
+        {
+          "id": "firestorm_heroic",
+          "name": "Firestorm",
+          "cooldown": 15,
+          "chance": 0.5,
+          "effects": [
+            {
+              "type": "damage",
+              "damageType": "fire",
+              "multiplier": 1.3
+            },
+            {
+              "type": "debuff",
+              "debuffType": "dot",
+              "id": "immolation_dot_heroic",
+              "name": "Immolation (H)",
+              "duration": 9,
+              "damageType": "fire",
+              "totalDamage": {
+                "source": "base_value",
+                "multiplier": 210
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "yeti_matriarch",
+      "nom": "Yeti Matriarch",
+      "level": 8,
+      "famille": "Giant",
+      "isBoss": true,
+      "palier": 2,
+      "stats": {
+        "PV": 650,
+        "AttMin": 28,
+        "AttMax": 38,
+        "CritPct": 10,
+        "CritDmg": 150,
+        "Armure": 140,
+        "Vitesse": 3.0,
+        "Precision": 78,
+        "Esquive": 12
+      },
+      "abilities": [
+        {
+          "id": "ice_shards",
+          "name": "Ice Shards",
+          "cooldown": 12,
+          "chance": 0.6,
+          "effects": [
+            {
+              "type": "damage",
+              "damageType": "ice",
+              "multiplier": 1.3
+            }
+          ]
+        }
+      ],
+      "specificLootTable": [
+        "axe_of_the_deathbringer",
+        "set_silver_guard_helm",
+        "set_silver_guard_chest"
+      ],
+      "componentLoot": [
+        {
+          "id": "frozen_heart",
+          "chance": 0.25,
+          "quantity": 1
+        }
+      ]
+    },
+    {
+      "id": "yeti_matriarch_heroic",
+      "nom": "Yeti Matriarch Heroic",
+      "level": 58,
+      "famille": "Giant",
+      "isBoss": true,
+      "palier": 12,
+      "stats": {
+        "PV": 6500,
+        "AttMin": 130,
+        "AttMax": 180,
+        "CritPct": 15,
+        "CritDmg": 175,
+        "Armure": 780,
+        "Vitesse": 3.0,
+        "Precision": 130,
+        "Esquive": 22
+      },
+      "abilities": [
+        {
+          "id": "ice_shards_heroic",
+          "name": "Ice Shards Heroic",
+          "cooldown": 12,
+          "chance": 0.6,
+          "effects": [
+            {
+              "type": "damage",
+              "damageType": "ice",
+              "multiplier": 1.6
+            },
+            {
+              "type": "debuff",
+              "debuffType": "vulnerability",
+              "id": "ice_vuln_heroic",
+              "name": "Ice Vulnerability (H)",
+              "duration": 8,
+              "damageType": "ice",
+              "multiplier": 1.20
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "kobold_miner_assistant",
+      "nom": "Kobold Miner assistant",
+      "level": 2,
+      "famille": "Humanoid",
+      "isBoss": false,
+      "palier": 1,
+      "stats": {
+        "PV": 40,
+        "AttMin": 6,
+        "AttMax": 9,
+        "CritPct": 5,
+        "CritDmg": 150,
+        "Armure": 20,
+        "Vitesse": 2.8,
+        "Precision": 55,
+        "Esquive": 3
+      },
+      "componentLoot": [
+        {
+          "id": "copper_ingot",
+          "chance": 0.4,
+          "quantity": 1
+        }
+      ]
+    },
+    {
+      "id": "cave_bat",
+      "nom": "Cave Bat",
+      "level": 3,
+      "famille": "Beast",
+      "isBoss": false,
+      "palier": 1,
+      "stats": {
+        "PV": 35,
+        "AttMin": 7,
+        "AttMax": 10,
+        "CritPct": 8,
+        "CritDmg": 150,
+        "Armure": 10,
+        "Vitesse": 1.8,
+        "Precision": 60,
+        "Esquive": 15
+      },
+      "questItemId": "bat_fang",
+      "componentLoot": [
+        {
+          "id": "light_leather",
+          "chance": 0.35,
+          "quantity": 1
+        }
+      ]
+    },
+    {
+      "id": "frost_wolf",
+      "nom": "Frost Wolf",
+      "level": 4,
+      "famille": "Beast",
+      "isBoss": false,
+      "palier": 2,
+      "stats": {
+        "PV": 80,
+        "AttMin": 12,
+        "AttMax": 18,
+        "CritPct": 10,
+        "CritDmg": 150,
+        "Armure": 40,
+        "Vitesse": 2.2,
+        "Precision": 65,
+        "Esquive": 10
+      }
+    },
+    {
+      "id": "ice_sprite",
+      "nom": "Ice Sprite",
+      "level": 5,
+      "famille": "Elemental",
+      "isBoss": false,
+      "palier": 2,
+      "stats": {
+        "PV": 60,
+        "AttMin": 15,
+        "AttMax": 20,
+        "CritPct": 5,
+        "CritDmg": 150,
+        "Armure": 25,
+        "Vitesse": 2,
+        "Precision": 70,
+        "Esquive": 18,
+        "ResElems": {
+          "ice": 25,
+          "fire": -10
+        }
+      }
+    },
+    {
+      "id": "yeti_toddler",
+      "nom": "Yeti Toddler",
+      "level": 6,
+      "famille": "Giant",
+      "isBoss": false,
+      "palier": 2,
+      "stats": {
+        "PV": 150,
+        "AttMin": 10,
+        "AttMax": 15,
+        "CritPct": 3,
+        "CritDmg": 150,
+        "Armure": 60,
+        "Vitesse": 3,
+        "Precision": 60,
+        "Esquive": 5
+      }
+    },
+    {
+      "id": "volcanic_imp",
+      "nom": "Volcanic Imp",
+      "level": 7,
+      "famille": "Demon",
+      "isBoss": false,
+      "palier": 3,
+      "stats": {
+        "PV": 120,
+        "AttMin": 20,
+        "AttMax": 25,
+        "CritPct": 8,
+        "CritDmg": 160,
+        "Armure": 50,
+        "Vitesse": 2.1,
+        "Precision": 75,
+        "Esquive": 12
+      }
+    },
+    {
+      "id": "magma_salamander",
+      "nom": "Magma Salamander",
+      "level": 8,
+      "famille": "Elemental",
+      "isBoss": false,
+      "palier": 3,
+      "stats": {
+        "PV": 180,
+        "AttMin": 18,
+        "AttMax": 28,
+        "CritPct": 5,
+        "CritDmg": 150,
+        "Armure": 70,
+        "Vitesse": 2.8,
+        "Precision": 70,
+        "Esquive": 8
+      }
+    },
+    {
+      "id": "cinder_elemental",
+      "nom": "Cinder Elemental",
+      "level": 9,
+      "famille": "Elemental",
+      "isBoss": false,
+      "palier": 3,
+      "stats": {
+        "PV": 150,
+        "AttMin": 25,
+        "AttMax": 30,
+        "CritPct": 5,
+        "CritDmg": 150,
+        "Armure": 40,
+        "Vitesse": 2.5,
+        "Precision": 75,
+        "Esquive": 10,
+        "ResElems": {
+          "fire": 25,
+          "ice": -10
+        }
+      },
+      "componentLoot": [
+        {
+          "id": "eternal_fire",
+          "chance": 0.15,
+          "quantity": 1
+        }
+      ]
+    },
+    {
+      "id": "cursed_sapling",
+      "nom": "Cursed Sapling",
+      "level": 10,
+      "famille": "Plant",
+      "isBoss": false,
+      "palier": 4,
+      "stats": {
+        "PV": 250,
+        "AttMin": 28,
+        "AttMax": 35,
+        "CritPct": 5,
+        "CritDmg": 150,
+        "Armure": 100,
+        "Vitesse": 3,
+        "Precision": 75,
+        "Esquive": 5
+      }
+    },
+    {
+      "id": "thorn_boar",
+      "nom": "Thorn Boar",
+      "level": 11,
+      "famille": "Beast",
+      "isBoss": false,
+      "palier": 4,
+      "stats": {
+        "PV": 300,
+        "AttMin": 30,
+        "AttMax": 40,
+        "CritPct": 8,
+        "CritDmg": 150,
+        "Armure": 120,
+        "Vitesse": 2.6,
+        "Precision": 70,
+        "Esquive": 8
+      }
+    },
+    {
+      "id": "wandering_dryad",
+      "nom": "Wandering Dryad",
+      "level": 12,
+      "famille": "Fey",
+      "isBoss": false,
+      "palier": 4,
+      "stats": {
+        "PV": 220,
+        "AttMin": 35,
+        "AttMax": 45,
+        "CritPct": 10,
+        "CritDmg": 160,
+        "Armure": 80,
+        "Vitesse": 2.2,
+        "Precision": 80,
+        "Esquive": 15
+      }
+    },
+    {
+      "id": "ghoul",
+      "nom": "Ghoul",
+      "level": 13,
+      "famille": "Undead",
+      "isBoss": false,
+      "palier": 5,
+      "stats": {
+        "PV": 400,
+        "AttMin": 40,
+        "AttMax": 50,
+        "CritPct": 7,
+        "CritDmg": 150,
+        "Armure": 150,
+        "Vitesse": 2.8,
+        "Precision": 80,
+        "Esquive": 10
+      }
+    },
+    {
+      "id": "shadow_wisp",
+      "nom": "Shadow Wisp",
+      "level": 14,
+      "famille": "Aberration",
+      "isBoss": false,
+      "palier": 5,
+      "stats": {
+        "PV": 300,
+        "AttMin": 50,
+        "AttMax": 60,
+        "CritPct": 12,
+        "CritDmg": 170,
+        "Armure": 100,
+        "Vitesse": 1.9,
+        "Precision": 85,
+        "Esquive": 20,
+        "ResElems": {
+          "shadow": 25
+        }
+      },
+      "componentLoot": [
+        {
+          "id": "frozen_shadow",
+          "chance": 0.1,
+          "quantity": 1
+        }
+      ]
+    },
+    {
+      "id": "acolyte_of_the_void",
+      "nom": "Acolyte of the Void",
+      "level": 15,
+      "famille": "Humanoid",
+      "isBoss": false,
+      "palier": 5,
+      "stats": {
+        "PV": 350,
+        "AttMin": 45,
+        "AttMax": 55,
+        "CritPct": 10,
+        "CritDmg": 160,
+        "Armure": 120,
+        "Vitesse": 2.4,
+        "Precision": 85,
+        "Esquive": 15
+      }
+    },
+    {
+      "id": "cultist_initiate",
+      "nom": "Cultist Initiate",
+      "level": 15,
+      "famille": "Humanoid",
+      "isBoss": false,
+      "palier": 5,
+      "stats": {
+        "PV": 380,
+        "AttMin": 42,
+        "AttMax": 53,
+        "CritPct": 8,
+        "CritDmg": 150,
+        "Armure": 140,
+        "Vitesse": 2.6,
+        "Precision": 82,
+        "Esquive": 12
+      }
+    },
+    {
+      "id": "polar_bear",
+      "nom": "Polar Bear",
+      "level": 16,
+      "famille": "Beast",
+      "isBoss": false,
+      "palier": 6,
+      "stats": {
+        "PV": 550,
+        "AttMin": 55,
+        "AttMax": 70,
+        "CritPct": 8,
+        "CritDmg": 150,
+        "Armure": 250,
+        "Vitesse": 2.9,
+        "Precision": 80,
+        "Esquive": 10
+      }
+    },
+    {
+      "id": "glacial_elemental",
+      "nom": "Glacial Elemental",
+      "level": 17,
+      "famille": "Elemental",
+      "isBoss": false,
+      "palier": 6,
+      "stats": {
+        "PV": 450,
+        "AttMin": 65,
+        "AttMax": 80,
+        "CritPct": 5,
+        "CritDmg": 150,
+        "Armure": 180,
+        "Vitesse": 2.7,
+        "Precision": 85,
+        "Esquive": 15,
+        "ResElems": {
+          "ice": 30,
+          "fire": -15
+        }
+      },
+      "componentLoot": [
+        {
+          "id": "crystalline_water",
+          "chance": 0.15,
+          "quantity": 1
+        }
+      ]
+    },
+    {
+      "id": "ice_wraith",
+      "nom": "Ice Wraith",
+      "level": 18,
+      "famille": "Undead",
+      "isBoss": false,
+      "palier": 6,
+      "stats": {
+        "PV": 400,
+        "AttMin": 70,
+        "AttMax": 85,
+        "CritPct": 12,
+        "CritDmg": 160,
+        "Armure": 150,
+        "Vitesse": 2.2,
+        "Precision": 90,
+        "Esquive": 22
+      },
+      "abilities": [
+        {
+          "id": "monster_frost_attack",
+          "name": "Attaque de givre",
+          "cooldown": 10,
+          "chance": 0.5,
+          "effects": [
+            {
+              "type": "debuff",
+              "debuffType": "stat_modifier",
+              "id": "monster_frost_slow",
+              "name": "Ralentissement glacial",
+              "duration": 6,
+              "statMods": [
+                {
+                  "stat": "Vitesse",
+                  "modifier": "multiplicative",
+                  "value": 1.30
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "frozen_berserker",
+      "nom": "Frozen Berserker",
+      "level": 18,
+      "famille": "Humanoid",
+      "isBoss": false,
+      "palier": 6,
+      "stats": {
+        "PV": 600,
+        "AttMin": 60,
+        "AttMax": 75,
+        "CritPct": 10,
+        "CritDmg": 150,
+        "Armure": 220,
+        "Vitesse": 3,
+        "Precision": 82,
+        "Esquive": 8
+      }
+    },
+    {
+      "id": "pyroclastic_golem",
+      "nom": "Pyroclastic Golem",
+      "level": 19,
+      "famille": "Construct",
+      "isBoss": false,
+      "palier": 7,
+      "stats": {
+        "PV": 800,
+        "AttMin": 75,
+        "AttMax": 90,
+        "CritPct": 5,
+        "CritDmg": 150,
+        "Armure": 400,
+        "Vitesse": 3.5,
+        "Precision": 85,
+        "Esquive": 5
+      }
+    },
+    {
+      "id": "hell_hound",
+      "nom": "Hell Hound",
+      "level": 20,
+      "famille": "Beast",
+      "isBoss": false,
+      "palier": 7,
+      "stats": {
+        "PV": 550,
+        "AttMin": 76,
+        "AttMax": 90,
+        "CritPct": 15,
+        "CritDmg": 170,
+        "Armure": 280,
+        "Vitesse": 2.3,
+        "Precision": 90,
+        "Esquive": 18
+      },
+      "abilities": [
+        {
+          "id": "monster_fire_breath",
+          "name": "Souffle de feu",
+          "cooldown": 12,
+          "chance": 0.4,
+          "effects": [
+            {
+              "type": "debuff",
+              "debuffType": "dot",
+              "id": "monster_fire_dot",
+              "name": "Brûlure infernale",
+              "duration": 9,
+              "damageType": "fire",
+              "totalDamage": {
+                "source": "base_value",
+                "multiplier": 45
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "obsidian_gargoyle",
+      "nom": "Obsidian Gargoyle",
+      "level": 21,
+      "famille": "Construct",
+      "isBoss": false,
+      "palier": 7,
+      "stats": {
+        "PV": 600,
+        "AttMin": 74,
+        "AttMax": 87,
+        "CritPct": 8,
+        "CritDmg": 150,
+        "Armure": 350,
+        "Vitesse": 2.8,
+        "Precision": 88,
+        "Esquive": 12
+      }
+    },
+    {
+      "id": "fire_giant_scout",
+      "nom": "Fire Giant Scout",
+      "level": 21,
+      "famille": "Giant",
+      "isBoss": false,
+      "palier": 7,
+      "stats": {
+        "PV": 765,
+        "AttMin": 80,
+        "AttMax": 95,
+        "CritPct": 7,
+        "CritDmg": 150,
+        "Armure": 380,
+        "Vitesse": 3.2,
+        "Precision": 85,
+        "Esquive": 7
+      }
+    },
+    {
+      "id": "razorvine_creeper",
+      "nom": "Razorvine Creeper",
+      "level": 22,
+      "famille": "Plant",
+      "isBoss": false,
+      "palier": 8,
+      "stats": {
+        "PV": 720,
+        "AttMin": 85,
+        "AttMax": 104,
+        "CritPct": 10,
+        "CritDmg": 160,
+        "Armure": 300,
+        "Vitesse": 2.5,
+        "Precision": 90,
+        "Esquive": 15
+      }
+    },
+    {
+      "id": "ancient_treant",
+      "nom": "Ancient Treant",
+      "level": 23,
+      "famille": "Plant",
+      "isBoss": false,
+      "palier": 8,
+      "stats": {
+        "PV": 1020,
+        "AttMin": 95,
+        "AttMax": 114,
+        "CritPct": 5,
+        "CritDmg": 150,
+        "Armure": 500,
+        "Vitesse": 4,
+        "Precision": 90,
+        "Esquive": 5
+      }
+    },
+    {
+      "id": "grove_sentinel",
+      "nom": "Grove Sentinel",
+      "level": 24,
+      "famille": "Construct",
+      "isBoss": false,
+      "palier": 8,
+      "stats": {
+        "PV": 850,
+        "AttMin": 90,
+        "AttMax": 109,
+        "CritPct": 7,
+        "CritDmg": 150,
+        "Armure": 450,
+        "Vitesse": 3.3,
+        "Precision": 88,
+        "Esquive": 8
+      }
+    },
+    {
+      "id": "sylvan_protector",
+      "nom": "Sylvan Protector",
+      "level": 24,
+      "famille": "Fey",
+      "isBoss": false,
+      "palier": 8,
+      "stats": {
+        "PV": 765,
+        "AttMin": 99,
+        "AttMax": 118,
+        "CritPct": 12,
+        "CritDmg": 160,
+        "Armure": 350,
+        "Vitesse": 2.4,
+        "Precision": 92,
+        "Esquive": 18
+      }
+    },
+    {
+      "id": "wraith",
+      "nom": "Wraith",
+      "level": 25,
+      "famille": "Undead",
+      "isBoss": false,
+      "palier": 9,
+      "stats": {
+        "PV": 800,
+        "AttMin": 114,
+        "AttMax": 133,
+        "CritPct": 15,
+        "CritDmg": 180,
+        "Armure": 300,
+        "Vitesse": 2,
+        "Precision": 95,
+        "Esquive": 25
+      },
+      "componentLoot": [
+        {
+          "id": "frozen_shadow",
+          "chance": 0.1,
+          "quantity": 1
+        }
+      ]
+    },
+    {
+      "id": "mind_flayer_spawn",
+      "nom": "Mind Flayer Spawn",
+      "level": 26,
+      "famille": "Aberration",
+      "isBoss": false,
+      "palier": 9,
+      "stats": {
+        "PV": 935,
+        "AttMin": 104,
+        "AttMax": 123,
+        "CritPct": 10,
+        "CritDmg": 160,
+        "Armure": 350,
+        "Vitesse": 2.6,
+        "Precision": 95,
+        "Esquive": 15
+      }
+    },
+    {
+      "id": "void_terror",
+      "nom": "Void Terror",
+      "level": 27,
+      "famille": "Aberration",
+      "isBoss": false,
+      "palier": 9,
+      "stats": {
+        "PV": 1275,
+        "AttMin": 118,
+        "AttMax": 142,
+        "CritPct": 8,
+        "CritDmg": 150,
+        "Armure": 500,
+        "Vitesse": 3.1,
+        "Precision": 92,
+        "Esquive": 10
+      }
+    },
+    {
+      "id": "shambling_horror",
+      "nom": "Shambling Horror",
+      "level": 27,
+      "famille": "Aberration",
+      "isBoss": false,
+      "palier": 9,
+      "stats": {
+        "PV": 1360,
+        "AttMin": 114,
+        "AttMax": 137,
+        "CritPct": 5,
+        "CritDmg": 150,
+        "Armure": 550,
+        "Vitesse": 3.8,
+        "Precision": 90,
+        "Esquive": 5
+      }
+    },
+    {
+      "id": "specter",
+      "nom": "Specter",
+      "level": 27,
+      "famille": "Undead",
+      "isBoss": false,
+      "palier": 9,
+      "stats": {
+        "PV": 765,
+        "AttMin": 123,
+        "AttMax": 147,
+        "CritPct": 18,
+        "CritDmg": 180,
+        "Armure": 280,
+        "Vitesse": 1.8,
+        "Precision": 98,
+        "Esquive": 30
+      }
+    },
+    {
+      "id": "frost_giant",
+      "nom": "Frost Giant",
+      "level": 28,
+      "famille": "Giant",
+      "isBoss": false,
+      "palier": 10,
+      "stats": {
+        "PV": 1700,
+        "AttMin": 142,
+        "AttMax": 171,
+        "CritPct": 8,
+        "CritDmg": 150,
+        "Armure": 700,
+        "Vitesse": 3.5,
+        "Precision": 95,
+        "Esquive": 8
+      }
+    },
+    {
+      "id": "rime-scaled_drake",
+      "nom": "Rime-scaled Drake",
+      "level": 29,
+      "famille": "Dragonkin",
+      "isBoss": false,
+      "palier": 10,
+      "stats": {
+        "PV": 1530,
+        "AttMin": 152,
+        "AttMax": 180,
+        "CritPct": 12,
+        "CritDmg": 160,
+        "Armure": 600,
+        "Vitesse": 2.8,
+        "Precision": 98,
+        "Esquive": 15
+      }
+    },
+    {
+      "id": "mammoth_calf",
+      "nom": "Mammoth Calf",
+      "level": 30,
+      "famille": "Beast",
+      "isBoss": false,
+      "palier": 10,
+      "stats": {
+        "PV": 2050,
+        "AttMin": 128,
+        "AttMax": 156,
+        "CritPct": 5,
+        "CritDmg": 150,
+        "Armure": 800,
+        "Vitesse": 4,
+        "Precision": 90,
+        "Esquive": 5
+      }
+    },
+    {
+      "id": "wendigo_spawn",
+      "nom": "Wendigo Spawn",
+      "level": 30,
+      "famille": "Aberration",
+      "isBoss": false,
+      "palier": 10,
+      "stats": {
+        "PV": 1400,
+        "AttMin": 156,
+        "AttMax": 184,
+        "CritPct": 18,
+        "CritDmg": 170,
+        "Armure": 550,
+        "Vitesse": 2.5,
+        "Precision": 100,
+        "Esquive": 20
+      }
+    },
+    {
+      "id": "boreal_knight",
+      "nom": "Boreal Knight",
+      "level": 30,
+      "famille": "Humanoid",
+      "isBoss": false,
+      "palier": 10,
+      "stats": {
+        "PV": 1800,
+        "AttMin": 142,
+        "AttMax": 170,
+        "CritPct": 10,
+        "CritDmg": 150,
+        "Armure": 750,
+        "Vitesse": 3,
+        "Precision": 95,
+        "Esquive": 12
+      }
+    },
+    {
+      "id": "infernal_juggernaut",
+      "nom": "Infernal Juggernaut",
+      "level": 31,
+      "famille": "Demon",
+      "isBoss": false,
+      "palier": 11,
+      "stats": {
+        "PV": 2460,
+        "AttMin": 165,
+        "AttMax": 193,
+        "CritPct": 7,
+        "CritDmg": 150,
+        "Armure": 1000,
+        "Vitesse": 3.8,
+        "Precision": 98,
+        "Esquive": 7
+      }
+    },
+    {
+      "id": "magma_dragon_whelp",
+      "nom": "Magma Dragon Whelp",
+      "level": 32,
+      "famille": "Dragonkin",
+      "isBoss": false,
+      "palier": 11,
+      "stats": {
+        "PV": 2050,
+        "AttMin": 174,
+        "AttMax": 202,
+        "CritPct": 12,
+        "CritDmg": 160,
+        "Armure": 850,
+        "Vitesse": 2.9,
+        "Precision": 100,
+        "Esquive": 15
+      }
+    },
+    {
+      "id": "flame_hydra",
+      "nom": "Flame Hydra",
+      "level": 33,
+      "famille": "Beast",
+      "isBoss": false,
+      "palier": 11,
+      "stats": {
+        "PV": 2300,
+        "AttMin": 184,
+        "AttMax": 211,
+        "CritPct": 10,
+        "CritDmg": 150,
+        "Armure": 900,
+        "Vitesse": 2.7,
+        "Precision": 100,
+        "Esquive": 12
+      }
+    },
+    {
+      "id": "brimstone_devil",
+      "nom": "Brimstone Devil",
+      "level": 33,
+      "famille": "Demon",
+      "isBoss": false,
+      "palier": 11,
+      "stats": {
+        "PV": 1900,
+        "AttMin": 193,
+        "AttMax": 220,
+        "CritPct": 18,
+        "CritDmg": 170,
+        "Armure": 750,
+        "Vitesse": 2.2,
+        "Precision": 105,
+        "Esquive": 22
+      }
+    },
+    {
+      "id": "ash_harpy",
+      "nom": "Ash Harpy",
+      "level": 33,
+      "famille": "Beast",
+      "isBoss": false,
+      "palier": 11,
+      "stats": {
+        "PV": 1800,
+        "AttMin": 188,
+        "AttMax": 216,
+        "CritPct": 20,
+        "CritDmg": 180,
+        "Armure": 700,
+        "Vitesse": 2,
+        "Precision": 110,
+        "Esquive": 28
+      }
+    },
+    {
+      "id": "colossal_carnivorous_plant",
+      "nom": "Colossal Carnivorous Plant",
+      "level": 34,
+      "famille": "Plant",
+      "isBoss": false,
+      "palier": 12,
+      "stats": {
+        "PV": 3280,
+        "AttMin": 202,
+        "AttMax": 230,
+        "CritPct": 8,
+        "CritDmg": 150,
+        "Armure": 1200,
+        "Vitesse": 3.6,
+        "Precision": 100,
+        "Esquive": 8
+      }
+    },
+    {
+      "id": "verdant_wyrm",
+      "nom": "Verdant Wyrm",
+      "level": 35,
+      "famille": "Dragonkin",
+      "isBoss": false,
+      "palier": 12,
+      "stats": {
+        "PV": 2870,
+        "AttMin": 211,
+        "AttMax": 239,
+        "CritPct": 12,
+        "CritDmg": 160,
+        "Armure": 1000,
+        "Vitesse": 2.9,
+        "Precision": 105,
+        "Esquive": 15
+      }
+    },
+    {
+      "id": "elf_ranger",
+      "nom": "Elf Ranger",
+      "level": 36,
+      "famille": "Humanoid",
+      "isBoss": false,
+      "palier": 12,
+      "stats": {
+        "PV": 2300,
+        "AttMin": 230,
+        "AttMax": 257,
+        "CritPct": 25,
+        "CritDmg": 180,
+        "Armure": 800,
+        "Vitesse": 2,
+        "Precision": 120,
+        "Esquive": 30
+      }
+    },
+    {
+      "id": "satyr_trickster",
+      "nom": "Satyr Trickster",
+      "level": 36,
+      "famille": "Fey",
+      "isBoss": false,
+      "palier": 12,
+      "stats": {
+        "PV": 2200,
+        "AttMin": 220,
+        "AttMax": 248,
+        "CritPct": 22,
+        "CritDmg": 175,
+        "Armure": 750,
+        "Vitesse": 1.8,
+        "Precision": 115,
+        "Esquive": 35
+      }
+    },
+    {
+      "id": "emerald_golem",
+      "nom": "Emerald Golem",
+      "level": 36,
+      "famille": "Construct",
+      "isBoss": false,
+      "palier": 12,
+      "stats": {
+        "PV": 3700,
+        "AttMin": 211,
+        "AttMax": 239,
+        "CritPct": 5,
+        "CritDmg": 150,
+        "Armure": 1500,
+        "Vitesse": 4,
+        "Precision": 100,
+        "Esquive": 5
+      },
+      "componentLoot": [
+        {
+          "id": "primordial_earth",
+          "chance": 0.15,
+          "quantity": 1
+        }
+      ]
+    },
+    {
+      "id": "dread_lich",
+      "nom": "Dread Lich",
+      "level": 37,
+      "famille": "Undead",
+      "isBoss": false,
+      "palier": 13,
+      "stats": {
+        "PV": 3100,
+        "AttMin": 276,
+        "AttMax": 312,
+        "CritPct": 15,
+        "CritDmg": 180,
+        "Armure": 1100,
+        "Vitesse": 2.5,
+        "Precision": 110,
+        "Esquive": 20
+      }
+    },
+    {
+      "id": "elder_thing",
+      "nom": "Elder Thing",
+      "level": 38,
+      "famille": "Aberration",
+      "isBoss": false,
+      "palier": 13,
+      "stats": {
+        "PV": 4100,
+        "AttMin": 257,
+        "AttMax": 294,
+        "CritPct": 10,
+        "CritDmg": 160,
+        "Armure": 1300,
+        "Vitesse": 3.3,
+        "Precision": 105,
+        "Esquive": 10
+      }
+    },
+    {
+      "id": "void_reaver",
+      "nom": "Void Reaver",
+      "level": 39,
+      "famille": "Demon",
+      "isBoss": false,
+      "palier": 13,
+      "stats": {
+        "PV": 3700,
+        "AttMin": 294,
+        "AttMax": 331,
+        "CritPct": 12,
+        "CritDmg": 170,
+        "Armure": 1200,
+        "Vitesse": 2.8,
+        "Precision": 115,
+        "Esquive": 18
+      }
+    },
+    {
+      "id": "bone_collector",
+      "nom": "Bone Collector",
+      "level": 39,
+      "famille": "Construct",
+      "isBoss": false,
+      "palier": 13,
+      "stats": {
+        "PV": 4500,
+        "AttMin": 266,
+        "AttMax": 303,
+        "CritPct": 8,
+        "CritDmg": 150,
+        "Armure": 1600,
+        "Vitesse": 3.7,
+        "Precision": 100,
+        "Esquive": 8
+      }
+    },
+    {
+      "id": "soul_eater",
+      "nom": "Soul Eater",
+      "level": 39,
+      "famille": "Aberration",
+      "isBoss": false,
+      "palier": 13,
+      "stats": {
+        "PV": 3450,
+        "AttMin": 303,
+        "AttMax": 340,
+        "CritPct": 18,
+        "CritDmg": 190,
+        "Armure": 1000,
+        "Vitesse": 2.3,
+        "Precision": 120,
+        "Esquive": 25
+      }
+    },
+    {
+      "id": "tomb_guardian",
+      "nom": "Tomb Guardian",
+      "level": 39,
+      "famille": "Construct",
+      "isBoss": false,
+      "palier": 13,
+      "stats": {
+        "PV": 5000,
+        "AttMin": 276,
+        "AttMax": 322,
+        "CritPct": 5,
+        "CritDmg": 150,
+        "Armure": 2000,
+        "Vitesse": 4.2,
+        "Precision": 100,
+        "Esquive": 5
+      }
+    },
+    {
+      "id": "ancient_frost_wyrm",
+      "nom": "Ancient Frost Wyrm",
+      "level": 40,
+      "famille": "Dragonkin",
+      "isBoss": true,
+      "palier": 14,
+      "stats": {
+        "PV": 12000,
+        "AttMin": 360,
+        "AttMax": 405,
+        "CritPct": 15,
+        "CritDmg": 180,
+        "Armure": 2500,
+        "Vitesse": 3,
+        "Precision": 120,
+        "Esquive": 15
+      },
+      "abilities": [
+        {
+          "id": "deep_freeze",
+          "name": "Gelure profonde",
+          "cooldown": 20,
+          "chance": 0.3,
+          "effects": [
+            {
+              "type": "debuff",
+              "debuffType": "cc",
+              "id": "deep_freeze_stun",
+              "name": "Gelé",
+              "duration": 4,
+              "ccType": "stun"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "ice_titan",
+      "nom": "Ice Titan",
+      "level": 41,
+      "famille": "Giant",
+      "isBoss": false,
+      "palier": 14,
+      "stats": {
+        "PV": 6400,
+        "AttMin": 315,
+        "AttMax": 360,
+        "CritPct": 10,
+        "CritDmg": 150,
+        "Armure": 2200,
+        "Vitesse": 3.8,
+        "Precision": 110,
+        "Esquive": 10
+      }
+    },
+    {
+      "id": "avalanche_spirit",
+      "nom": "Avalanche Spirit",
+      "level": 42,
+      "famille": "Elemental",
+      "isBoss": false,
+      "palier": 14,
+      "stats": {
+        "PV": 5200,
+        "AttMin": 342,
+        "AttMax": 387,
+        "CritPct": 12,
+        "CritDmg": 160,
+        "Armure": 1800,
+        "Vitesse": 2.7,
+        "Precision": 115,
+        "Esquive": 20
+      }
+    },
+    {
+      "id": "yeti_patriarch",
+      "nom": "Yeti Patriarch",
+      "level": 42,
+      "famille": "Giant",
+      "isBoss": false,
+      "palier": 14,
+      "stats": {
+        "PV": 7200,
+        "AttMin": 324,
+        "AttMax": 369,
+        "CritPct": 8,
+        "CritDmg": 150,
+        "Armure": 2400,
+        "Vitesse": 4,
+        "Precision": 105,
+        "Esquive": 8
+      }
+    },
+    {
+      "id": "frost-forged_sentinel",
+      "nom": "Frost-forged Sentinel",
+      "level": 42,
+      "famille": "Construct",
+      "isBoss": false,
+      "palier": 14,
+      "stats": {
+        "PV": 8000,
+        "AttMin": 306,
+        "AttMax": 351,
+        "CritPct": 5,
+        "CritDmg": 150,
+        "Armure": 3000,
+        "Vitesse": 4.5,
+        "Precision": 100,
+        "Esquive": 5
+      }
+    },
+    {
+      "id": "seraphim_of_ice",
+      "nom": "Seraphim of Ice",
+      "level": 42,
+      "famille": "Celestial",
+      "isBoss": false,
+      "palier": 14,
+      "stats": {
+        "PV": 5600,
+        "AttMin": 360,
+        "AttMax": 405,
+        "CritPct": 20,
+        "CritDmg": 190,
+        "Armure": 1600,
+        "Vitesse": 2.4,
+        "Precision": 125,
+        "Esquive": 28
+      }
+    },
+    {
+      "id": "primeval_magma_dragon",
+      "nom": "Primeval Magma Dragon",
+      "level": 43,
+      "famille": "Dragonkin",
+      "isBoss": true,
+      "palier": 15,
+      "stats": {
+        "PV": 14400,
+        "AttMin": 405,
+        "AttMax": 450,
+        "CritPct": 15,
+        "CritDmg": 180,
+        "Armure": 2800,
+        "Vitesse": 3,
+        "Precision": 125,
+        "Esquive": 15
+      },
+      "abilities": [
+        {
+          "id": "magma_breath",
+          "name": "Souffle de Magma",
+          "cooldown": 20,
+          "chance": 0.5,
+          "effects": [
+            {
+              "type": "damage",
+              "damageType": "fire",
+              "multiplier": 1.5
+            },
+            {
+              "type": "debuff",
+              "debuffType": "vulnerability",
+              "id": "magma_vuln",
+              "name": "Armure fondue",
+              "duration": 10,
+              "damageType": "all",
+              "multiplier": 1.15
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "balrog",
+      "nom": "Balrog",
+      "level": 44,
+      "famille": "Demon",
+      "isBoss": false,
+      "palier": 15,
+      "stats": {
+        "PV": 9600,
+        "AttMin": 450,
+        "AttMax": 495,
+        "CritPct": 20,
+        "CritDmg": 200,
+        "Armure": 2500,
+        "Vitesse": 2.6,
+        "Precision": 130,
+        "Esquive": 20
+      }
+    },
+    {
+      "id": "phoenix",
+      "nom": "Phoenix",
+      "level": 45,
+      "famille": "Celestial",
+      "isBoss": false,
+      "palier": 15,
+      "stats": {
+        "PV": 8000,
+        "AttMin": 432,
+        "AttMax": 477,
+        "CritPct": 18,
+        "CritDmg": 190,
+        "Armure": 2200,
+        "Vitesse": 2.2,
+        "Precision": 135,
+        "Esquive": 30
+      }
+    },
+    {
+      "id": "efreeti_sultan",
+      "nom": "Efreeti Sultan",
+      "level": 45,
+      "famille": "Elemental",
+      "isBoss": false,
+      "palier": 15,
+      "stats": {
+        "PV": 10400,
+        "AttMin": 414,
+        "AttMax": 459,
+        "CritPct": 12,
+        "CritDmg": 160,
+        "Armure": 3000,
+        "Vitesse": 3.2,
+        "Precision": 120,
+        "Esquive": 12
+      }
+    },
+    {
+      "id": "volcanic_titan",
+      "nom": "Volcanic Titan",
+      "level": 45,
+      "famille": "Giant",
+      "isBoss": false,
+      "palier": 15,
+      "stats": {
+        "PV": 12000,
+        "AttMin": 396,
+        "AttMax": 441,
+        "CritPct": 10,
+        "CritDmg": 150,
+        "Armure": 3500,
+        "Vitesse": 4.2,
+        "Precision": 115,
+        "Esquive": 8
+      }
+    },
+    {
+      "id": "charred_legionnaire",
+      "nom": "Charred Legionnaire",
+      "level": 45,
+      "famille": "Undead",
+      "isBoss": false,
+      "palier": 15,
+      "stats": {
+        "PV": 8800,
+        "AttMin": 423,
+        "AttMax": 468,
+        "CritPct": 15,
+        "CritDmg": 170,
+        "Armure": 2600,
+        "Vitesse": 2.9,
+        "Precision": 125,
+        "Esquive": 18
+      }
+    },
+    {
+      "id": "world_ash_treant",
+      "nom": "World Ash Treant",
+      "level": 46,
+      "famille": "Plant",
+      "isBoss": true,
+      "palier": 16,
+      "stats": {
+        "PV": 20000,
+        "AttMin": 495,
+        "AttMax": 540,
+        "CritPct": 10,
+        "CritDmg": 160,
+        "Armure": 4000,
+        "Vitesse": 4.5,
+        "Precision": 130,
+        "Esquive": 10
+      },
+      "abilities": [
+        {
+          "id": "ashes_of_the_world",
+          "name": "Cendres du Monde",
+          "cooldown": 25,
+          "chance": 0.4,
+          "effects": [
+            {
+              "type": "buff",
+              "buffType": "stat_modifier",
+              "id": "world_ash_dmg_buff",
+              "name": "Puissance des cendres",
+              "duration": 15,
+              "statMods": [
+                {
+                  "stat": "AttMin",
+                  "modifier": "multiplicative",
+                  "value": 1.25
+                },
+                {
+                  "stat": "AttMax",
+                  "modifier": "multiplicative",
+                  "value": 1.25
+                }
+              ]
+            },
+            {
+              "type": "debuff",
+              "debuffType": "dot",
+              "id": "world_ash_aura",
+              "name": "Aura de cendres",
+              "duration": 15,
+              "damageType": "fire",
+              "totalDamage": {
+                "source": "base_value",
+                "multiplier": 350
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "gaia_avatar",
+      "nom": "Gaia's Avatar",
+      "level": 47,
+      "famille": "Elemental",
+      "isBoss": false,
+      "palier": 16,
+      "stats": {
+        "PV": 16000,
+        "AttMin": 540,
+        "AttMax": 585,
+        "CritPct": 15,
+        "CritDmg": 180,
+        "Armure": 3500,
+        "Vitesse": 3.2,
+        "Precision": 140,
+        "Esquive": 20
+      }
+    },
+    {
+      "id": "archdruid_of_the_fang",
+      "nom": "Archdruid of the Fang",
+      "level": 48,
+      "famille": "Humanoid",
+      "isBoss": false,
+      "palier": 16,
+      "stats": {
+        "PV": 14400,
+        "AttMin": 585,
+        "AttMax": 630,
+        "CritPct": 25,
+        "CritDmg": 200,
+        "Armure": 3000,
+        "Vitesse": 2.5,
+        "Precision": 150,
+        "Esquive": 30
+      }
+    },
+    {
+      "id": "fenrir's_chosen",
+      "nom": "Fenrir's Chosen",
+      "level": 48,
+      "famille": "Beast",
+      "isBoss": false,
+      "palier": 16,
+      "stats": {
+        "PV": 15200,
+        "AttMin": 612,
+        "AttMax": 657,
+        "CritPct": 30,
+        "CritDmg": 220,
+        "Armure": 2800,
+        "Vitesse": 2,
+        "Precision": 160,
+        "Esquive": 35
+      }
+    },
+    {
+      "id": "fae_king",
+      "nom": "Fae King",
+      "level": 48,
+      "famille": "Fey",
+      "isBoss": false,
+      "palier": 16,
+      "stats": {
+        "PV": 13600,
+        "AttMin": 630,
+        "AttMax": 675,
+        "CritPct": 28,
+        "CritDmg": 210,
+        "Armure": 2600,
+        "Vitesse": 1.8,
+        "Precision": 170,
+        "Esquive": 40
+      }
+    },
+    {
+      "id": "living_world-tree",
+      "nom": "Living World-Tree",
+      "level": 48,
+      "famille": "Construct",
+      "isBoss": false,
+      "palier": 16,
+      "stats": {
+        "PV": 24000,
+        "AttMin": 522,
+        "AttMax": 567,
+        "CritPct": 8,
+        "CritDmg": 150,
+        "Armure": 5000,
+        "Vitesse": 5,
+        "Precision": 120,
+        "Esquive": 5
+      }
+    },
+    {
+      "id": "herald_of_cthulhu",
+      "nom": "Herald of Cthulhu",
+      "level": 49,
+      "famille": "Aberration",
+      "isBoss": true,
+      "palier": 17,
+      "stats": {
+        "PV": 32000,
+        "AttMin": 720,
+        "AttMax": 810,
+        "CritPct": 20,
+        "CritDmg": 200,
+        "Armure": 4500,
+        "Vitesse": 2.8,
+        "Precision": 160,
+        "Esquive": 25
+      },
+      "abilities": [
+        {
+          "id": "touch_of_the_void",
+          "name": "Toucher du Vide",
+          "cooldown": 18,
+          "chance": 0.5,
+          "effects": [
+            {
+              "type": "damage",
+              "damageType": "shadow",
+              "multiplier": 1.4
+            },
+            {
+              "type": "debuff",
+              "debuffType": "stat_modifier",
+              "id": "insanity_debuff",
+              "name": "Folie",
+              "duration": 12,
+              "statMods": [
+                {
+                  "stat": "Precision",
+                  "modifier": "multiplicative",
+                  "value": 0.75
+                },
+                {
+                  "stat": "Esquive",
+                  "modifier": "multiplicative",
+                  "value": 0.75
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "archlich_of_nar'thalas",
+      "nom": "Archlich of Nar'thalas",
+      "level": 50,
+      "famille": "Undead",
+      "isBoss": false,
+      "palier": 17,
+      "stats": {
+        "PV": 28000,
+        "AttMin": 810,
+        "AttMax": 900,
+        "CritPct": 25,
+        "CritDmg": 220,
+        "Armure": 4000,
+        "Vitesse": 2.4,
+        "Precision": 170,
+        "Esquive": 30
+      }
+    },
+    {
+      "id": "gibbering_mouther",
+      "nom": "Gibbering Mouther",
+      "level": 50,
+      "famille": "Aberration",
+      "isBoss": false,
+      "palier": 17,
+      "stats": {
+        "PV": 30400,
+        "AttMin": 765,
+        "AttMax": 855,
+        "CritPct": 18,
+        "CritDmg": 190,
+        "Armure": 4200,
+        "Vitesse": 3,
+        "Precision": 150,
+        "Esquive": 20
+      }
+    },
+    {
+      "id": "void_leviathan",
+      "nom": "Void Leviathan",
+      "level": 50,
+      "famille": "Aberration",
+      "isBoss": false,
+      "palier": 17,
+      "stats": {
+        "PV": 40000,
+        "AttMin": 738,
+        "AttMax": 828,
+        "CritPct": 12,
+        "CritDmg": 170,
+        "Armure": 6000,
+        "Vitesse": 4,
+        "Precision": 140,
+        "Esquive": 10
+      }
+    },
+    {
+      "id": "ethereal_devourer",
+      "nom": "Ethereal Devourer",
+      "level": 50,
+      "famille": "Aberration",
+      "isBoss": false,
+      "palier": 17,
+      "stats": {
+        "PV": 28800,
+        "AttMin": 855,
+        "AttMax": 945,
+        "CritPct": 28,
+        "CritDmg": 230,
+        "Armure": 3800,
+        "Vitesse": 2.2,
+        "Precision": 180,
+        "Esquive": 35
+      }
+    },
+    {
+      "id": "shadow_titan",
+      "nom": "Shadow Titan",
+      "level": 50,
+      "famille": "Giant",
+      "isBoss": false,
+      "palier": 17,
+      "stats": {
+        "PV": 48000,
+        "AttMin": 792,
+        "AttMax": 882,
+        "CritPct": 15,
+        "CritDmg": 180,
+        "Armure": 7000,
+        "Vitesse": 4.5,
+        "Precision": 150,
+        "Esquive": 12
+      }
+    },
+    {
+      "id": "death_knight_champion",
+      "nom": "Death Knight Champion",
+      "level": 50,
+      "famille": "Undead",
+      "isBoss": false,
+      "palier": 17,
+      "stats": {
+        "PV": 36000,
+        "AttMin": 828,
+        "AttMax": 918,
+        "CritPct": 22,
+        "CritDmg": 210,
+        "Armure": 5500,
+        "Vitesse": 2.9,
+        "Precision": 160,
+        "Esquive": 22
+      }
+    },
+    {
+      "id": "bat_matriarch",
+      "nom": "Matriarche des Cavernes",
+      "level": 5,
+      "famille": "Beast",
+      "isBoss": true,
+      "palier": 1,
+      "stats": {
+        "PV": 200,
+        "AttMin": 15,
+        "AttMax": 22,
+        "CritPct": 12,
+        "CritDmg": 150,
+        "Armure": 40,
+        "Vitesse": 2.0,
+        "Precision": 70,
+        "Esquive": 20
+      },
+      "abilities": [
+        {
+          "id": "piercing_screech",
+          "name": "Cri perçant",
+          "cooldown": 12,
+          "chance": 0.4,
+          "effects": [
+            {
+              "type": "debuff",
+              "debuffType": "stat_modifier",
+              "id": "screech_armor_down",
+              "name": "Armure brisée",
+              "duration": 8,
+              "statMods": [
+                {
+                  "stat": "Armure",
+                  "modifier": "multiplicative",
+                  "value": 0.85
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "yeti_chieftain",
+      "nom": "Chef de Clan Yéti",
+      "level": 8,
+      "famille": "Giant",
+      "isBoss": true,
+      "palier": 2,
+      "stats": {
+        "PV": 600,
+        "AttMin": 25,
+        "AttMax": 35,
+        "CritPct": 8,
+        "CritDmg": 150,
+        "Armure": 150,
+        "Vitesse": 3.2,
+        "Precision": 75,
+        "Esquive": 10
+      },
+      "abilities": [
+        {
+          "id": "ground_slam",
+          "name": "Frappe assommante",
+          "cooldown": 10,
+          "chance": 0.5,
+          "effects": [
+            {
+              "type": "damage",
+              "damageType": "physical",
+              "multiplier": 1.5
+            },
+            {
+              "type": "debuff",
+              "debuffType": "cc",
+              "id": "slam_stun",
+              "name": "Assommé",
+              "duration": 2,
+              "ccType": "stun"
+            }
+          ]
+        }
+      ],
+      "specificLootTable": [
+        "axe_of_the_deathbringer",
+        "set_silver_guard_helm",
+        "set_silver_guard_chest"
+      ],
+      "componentLoot": [
+        {
+          "id": "frozen_heart",
+          "chance": 0.25,
+          "quantity": 1
+        }
+      ]
+    },
+    {
+      "id": "inferno_elemental_lord",
+      "nom": "Seigneur Élémentaire des Cendres",
+      "level": 11,
+      "famille": "Elemental",
+      "isBoss": true,
+      "palier": 3,
+      "stats": {
+        "PV": 800,
+        "AttMin": 45,
+        "AttMax": 55,
+        "CritPct": 10,
+        "CritDmg": 150,
+        "Armure": 180,
+        "Vitesse": 2.7,
+        "Precision": 80,
+        "Esquive": 12,
+        "ResElems": {
+          "fire": 40,
+          "ice": -20
+        }
+      },
+      "abilities": [
+        {
+          "id": "immolation",
+          "name": "Immolation",
+          "cooldown": 12,
+          "chance": 0.5,
+          "effects": [
+            {
+              "type": "debuff",
+              "debuffType": "dot",
+              "id": "immolation_dot",
+              "name": "Immolation",
+              "duration": 6,
+              "damageType": "fire",
+              "totalDamage": {
+                "source": "base_value",
+                "multiplier": 90
+              }
+            }
+          ]
+        }
+      ],
+      "specificLootTable": [
+        "set_arcanist_cowl",
+        "set_arcanist_robe"
+      ],
+      "recipeLoot": [
+        {
+          "id": "enchant_superior_fire_resistance",
+          "chance": 0.1,
+          "quantity": 1
+        }
+      ]
+    },
+    {
+      "id": "ancient_dryad_matriarch",
+      "nom": "Matriarche Dryade Ancienne",
+      "level": 14,
+      "famille": "Fey",
+      "isBoss": true,
+      "palier": 4,
+      "stats": {
+        "PV": 1200,
+        "AttMin": 60,
+        "AttMax": 75,
+        "CritPct": 15,
+        "CritDmg": 160,
+        "Armure": 250,
+        "Vitesse": 2.4,
+        "Precision": 85,
+        "Esquive": 18
+      },
+      "abilities": [
+        {
+          "id": "barkskin",
+          "name": "Écorcefer",
+          "cooldown": 20,
+          "chance": 0.3,
+          "effects": [
+            {
+              "type": "buff",
+              "buffType": "stat_modifier",
+              "id": "barkskin_buff",
+              "name": "Écorcefer",
+              "duration": 10,
+              "statMods": [
+                {
+                  "stat": "Armure",
+                  "modifier": "multiplicative",
+                  "value": 2.0
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "specificLootTable": [
+        "set_shadow_shroud_mask",
+        "set_shadow_shroud_tunic"
+      ]
+    },
+    {
+      "id": "void_cultist_leader",
+      "nom": "Chef de Culte du Vide",
+      "level": 17,
+      "famille": "Humanoid",
+      "isBoss": true,
+      "palier": 5,
+      "stats": {
+        "PV": 1800,
+        "AttMin": 70,
+        "AttMax": 85,
+        "CritPct": 12,
+        "CritDmg": 150,
+        "Armure": 350,
+        "Vitesse": 2.8,
+        "Precision": 90,
+        "Esquive": 14
+      },
+      "abilities": [
+        {
+          "id": "void_bolt",
+          "name": "Trait du Vide",
+          "cooldown": 8,
+          "chance": 0.6,
+          "effects": [
+            {
+              "type": "damage",
+              "damageType": "shadow",
+              "multiplier": 1.2
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "void_priest",
+      "nom": "Prêtre du Vide",
+      "level": 17,
+      "famille": "Humanoid",
+      "isBoss": true,
+      "palier": 5,
+      "stats": {
+        "PV": 1900,
+        "AttMin": 75,
+        "AttMax": 90,
+        "CritPct": 14,
+        "CritDmg": 160,
+        "Armure": 380,
+        "Vitesse": 2.6,
+        "Precision": 92,
+        "Esquive": 16
+      },
+      "abilities": [
+        {
+          "id": "mind_flay",
+          "name": "Fouet mental",
+          "cooldown": 10,
+          "chance": 0.5,
+          "effects": [
+            {
+              "type": "debuff",
+              "debuffType": "dot",
+              "id": "mind_flay_dot",
+              "name": "Fouet mental",
+              "duration": 9,
+              "damageType": "shadow",
+              "totalDamage": {
+                "source": "base_value",
+                "multiplier": 120
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "icebound_warlord",
+      "nom": "Seigneur de Guerre Englacé",
+      "level": 20,
+      "famille": "Humanoid",
+      "isBoss": true,
+      "palier": 6,
+      "stats": {
+        "PV": 2125,
+        "AttMin": 90,
+        "AttMax": 109,
+        "CritPct": 15,
+        "CritDmg": 150,
+        "Armure": 500,
+        "Vitesse": 3.2,
+        "Precision": 95,
+        "Esquive": 10
+      },
+      "abilities": [
+        {
+          "id": "shattering_strike",
+          "name": "Frappe fracassante",
+          "cooldown": 12,
+          "chance": 0.4,
+          "effects": [
+            {
+              "type": "damage",
+              "damageType": "physical",
+              "multiplier": 1.4
+            },
+            {
+              "type": "debuff",
+              "debuffType": "stat_modifier",
+              "id": "shattering_armor_down",
+              "name": "Armure fracassée",
+              "duration": 10,
+              "statMods": [
+                {
+                  "stat": "Armure",
+                  "modifier": "multiplicative",
+                  "value": 0.80
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "specificLootTable": [
+        "rep_silver_vanguard_helm",
+        "rep_silver_vanguard_greataxe"
+      ]
+    },
+    {
+      "id": "fire_giant_champion",
+      "nom": "Champion Géant de Feu",
+      "level": 23,
+      "famille": "Giant",
+      "isBoss": true,
+      "palier": 7,
+      "stats": {
+        "PV": 2975,
+        "AttMin": 114,
+        "AttMax": 133,
+        "CritPct": 10,
+        "CritDmg": 150,
+        "Armure": 700,
+        "Vitesse": 3.4,
+        "Precision": 100,
+        "Esquive": 9
+      },
+      "abilities": [
+        {
+          "id": "scorching_smash",
+          "name": "Fracas incandescent",
+          "cooldown": 10,
+          "chance": 0.5,
+          "effects": [
+            {
+              "type": "damage",
+              "damageType": "fire",
+              "multiplier": 1.6
+            }
+          ]
+        }
+      ],
+      "specificLootTable": [
+        "rep_magma_callers_cowl",
+        "rep_magma_callers_staff"
+      ]
+    },
+    {
+      "id": "guardian_of_the_grove",
+      "nom": "Gardien du Bosquet",
+      "level": 26,
+      "famille": "Fey",
+      "isBoss": true,
+      "palier": 8,
+      "stats": {
+        "PV": 3825,
+        "AttMin": 142,
+        "AttMax": 171,
+        "CritPct": 18,
+        "CritDmg": 160,
+        "Armure": 800,
+        "Vitesse": 2.6,
+        "Precision": 105,
+        "Esquive": 20
+      },
+      "abilities": [
+        {
+          "id": "natures_grasp",
+          "name": "Poigne de la nature",
+          "cooldown": 15,
+          "chance": 0.4,
+          "effects": [
+            {
+              "type": "debuff",
+              "debuffType": "stat_modifier",
+              "id": "grasp_slow",
+              "name": "Ralenti",
+              "duration": 8,
+              "statMods": [
+                {
+                  "stat": "Vitesse",
+                  "modifier": "multiplicative",
+                  "value": 1.40
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "specificLootTable": [
+        "rep_silent_path_mask",
+        "rep_silent_path_daggers"
+      ]
+    },
+    {
+      "id": "spectral_overlord",
+      "nom": "Souverain Spectral",
+      "level": 29,
+      "famille": "Undead",
+      "isBoss": true,
+      "palier": 9,
+      "stats": {
+        "PV": 4675,
+        "AttMin": 180,
+        "AttMax": 209,
+        "CritPct": 22,
+        "CritDmg": 180,
+        "Armure": 900,
+        "Vitesse": 2.0,
+        "Precision": 110,
+        "Esquive": 32
+      },
+      "abilities": [
+        {
+          "id": "soul_drain",
+          "name": "Drain d'âme",
+          "cooldown": 12,
+          "chance": 0.5,
+          "effects": [
+            {
+              "type": "debuff",
+              "debuffType": "dot",
+              "id": "soul_drain_dot",
+              "name": "Drain d'âme",
+              "duration": 6,
+              "damageType": "shadow",
+              "totalDamage": {
+                "source": "base_value",
+                "multiplier": 150
+              }
+            }
+          ]
+        }
+      ],
+      "specificLootTable": [
+        "rep_faithsworn_diadem",
+        "rep_faithsworn_mace"
+      ]
+    },
+    {
+      "id": "boreal_crusader",
+      "nom": "Croisé Boréal",
+      "level": 32,
+      "famille": "Humanoid",
+      "isBoss": true,
+      "palier": 10,
+      "stats": {
+        "PV": 5740,
+        "AttMin": 211,
+        "AttMax": 248,
+        "CritPct": 15,
+        "CritDmg": 150,
+        "Armure": 1500,
+        "Vitesse": 3.2,
+        "Precision": 115,
+        "Esquive": 14
+      },
+      "abilities": [
+        {
+          "id": "crusader_strike",
+          "name": "Frappe du croisé",
+          "cooldown": 8,
+          "chance": 0.6,
+          "effects": [
+            {
+              "type": "damage",
+              "damageType": "holy",
+              "multiplier": 1.3
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "ashwing_matriarch",
+      "nom": "Matriarche Aile-de-Cendre",
+      "level": 35,
+      "famille": "Beast",
+      "isBoss": true,
+      "palier": 11,
+      "stats": {
+        "PV": 6560,
+        "AttMin": 257,
+        "AttMax": 294,
+        "CritPct": 25,
+        "CritDmg": 180,
+        "Armure": 1600,
+        "Vitesse": 2.2,
+        "Precision": 120,
+        "Esquive": 30
+      },
+      "abilities": [
+        {
+          "id": "wing_buffet",
+          "name": "Coup d'aile",
+          "cooldown": 18,
+          "chance": 0.3,
+          "effects": [
+            {
+              "type": "debuff",
+              "debuffType": "cc",
+              "id": "wing_buffet_stun",
+              "name": "Repoussé",
+              "duration": 2.5,
+              "ccType": "stun"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "colossus_of_the_grove",
+      "nom": "Colosse du Bosquet",
+      "level": 38,
+      "famille": "Construct",
+      "isBoss": true,
+      "palier": 12,
+      "stats": {
+        "PV": 9840,
+        "AttMin": 322,
+        "AttMax": 368,
+        "CritPct": 10,
+        "CritDmg": 150,
+        "Armure": 2500,
+        "Vitesse": 4.2,
+        "Precision": 125,
+        "Esquive": 7
+      },
+      "abilities": [
+        {
+          "id": "overgrowth",
+          "name": "Surcroissance",
+          "cooldown": 15,
+          "chance": 0.4,
+          "effects": [
+            {
+              "type": "debuff",
+              "debuffType": "stat_modifier",
+              "id": "overgrowth_slow",
+              "name": "Enraciné",
+              "duration": 6,
+              "statMods": [
+                {
+                  "stat": "Vitesse",
+                  "modifier": "multiplicative",
+                  "value": 1.5
+                }
+              ]
+            },
+            {
+              "type": "debuff",
+              "debuffType": "dot",
+              "id": "overgrowth_dot",
+              "name": "Ronces",
+              "duration": 6,
+              "damageType": "nature",
+              "totalDamage": {
+                "source": "base_value",
+                "multiplier": 180
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "ancient_tomb_protector",
+      "nom": "Protecteur de Tombe Ancien",
+      "level": 41,
+      "famille": "Construct",
+      "isBoss": true,
+      "palier": 13,
+      "stats": {
+        "PV": 12000,
+        "AttMin": 378,
+        "AttMax": 432,
+        "CritPct": 8,
+        "CritDmg": 150,
+        "Armure": 3500,
+        "Vitesse": 4.5,
+        "Precision": 130,
+        "Esquive": 6
+      },
+      "abilities": [
+        {
+          "id": "stone_form",
+          "name": "Forme de pierre",
+          "cooldown": 25,
+          "chance": 0.25,
+          "effects": [
+            {
+              "type": "buff",
+              "buffType": "stat_modifier",
+              "id": "stone_form_buff",
+              "name": "Forme de pierre",
+              "duration": 8,
+              "statMods": [
+                {
+                  "stat": "Armure",
+                  "modifier": "multiplicative",
+                  "value": 3.0
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "garak_frostfang",
+      "nom": "Garak, the Frostfang",
+      "level": 22,
+      "famille": "Dragonkin",
+      "isBoss": true,
+      "palier": 7,
+      "stats": {
+        "PV": 3500,
+        "AttMin": 120,
+        "AttMax": 150,
+        "CritPct": 15,
+        "CritDmg": 160,
+        "Armure": 800,
+        "Vitesse": 3.0,
+        "Precision": 100,
+        "Esquive": 12,
+        "ResElems": {
+          "ice": 50,
+          "fire": -25
+        }
+      },
+      "abilities": [
+        {
+          "id": "frost_breath",
+          "name": "Souffle de Givre",
+          "cooldown": 12,
+          "chance": 0.5,
+          "effects": [
+            {
+              "type": "damage",
+              "damageType": "ice",
+              "multiplier": 1.5
+            },
+            {
+              "type": "debuff",
+              "debuffType": "stat_modifier",
+              "id": "frost_breath_slow",
+              "name": "Souffle glacial",
+              "duration": 8,
+              "statMods": [
+                {
+                  "stat": "Vitesse",
+                  "modifier": "multiplicative",
+                  "value": 1.35
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "specificLootTable": [
+        "garaks_icy_maw",
+        "frostfang_bite"
+      ]
+    },
+    {
+      "id": "goblin_scout_heroic",
+      "nom": "Gobelin Éclaireur Héroïque",
+      "level": 51,
+      "famille": "Goblinoid",
+      "isBoss": false,
+      "palier": 11,
+      "stats": {
+        "PV": 300,
+        "AttMin": 25,
+        "AttMax": 40,
+        "CritPct": 10,
+        "CritDmg": 175,
+        "Armure": 50,
+        "Vitesse": 2.5,
+        "Precision": 100,
+        "Esquive": 15
+      }
+    },
+    {
+      "id": "giant_rat_heroic",
+      "nom": "Rat Géant Héroïque",
+      "level": 51,
+      "famille": "Beast",
+      "isBoss": false,
+      "palier": 11,
+      "stats": {
+        "PV": 250,
+        "AttMin": 20,
+        "AttMax": 35,
+        "CritPct": 8,
+        "CritDmg": 175,
+        "Armure": 25,
+        "Vitesse": 2.2,
+        "Precision": 95,
+        "Esquive": 18
+      }
+    },
+    {
+      "id": "kobold_miner_supervisor_heroic",
+      "nom": "Superviseur Mineur Kobold Héroïque",
+      "famille": "Humanoid",
+      "level": 53,
+      "isBoss": true,
+      "palier": 11,
+      "stats": {
+        "PV": 1500,
+        "AttMin": 60,
+        "AttMax": 90,
+        "CritPct": 15,
+        "CritDmg": 175,
+        "Armure": 250,
+        "Vitesse": 2.5,
+        "Precision": 115,
+        "Esquive": 15
+      },
+      "abilities": [
+        {
+          "id": "get_back_to_work",
+          "name": "Au travail !",
+          "cooldown": 15,
+          "chance": 0.4,
+          "effects": [
+            {
+              "type": "debuff",
+              "debuffType": "cc",
+              "id": "supervisor_stun",
+              "name": "Intimidation",
+              "duration": 2,
+              "ccType": "stun"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "kobold_miner_assistant_heroic",
+      "nom": "Assistant Mineur Kobold Héroïque",
+      "level": 52,
+      "famille": "Humanoid",
+      "isBoss": false,
+      "palier": 11,
+      "stats": {
+        "PV": 400,
+        "AttMin": 30,
+        "AttMax": 45,
+        "CritPct": 10,
+        "CritDmg": 175,
+        "Armure": 100,
+        "Vitesse": 2.8,
+        "Precision": 105,
+        "Esquive": 13
+      }
+    },
+    {
+      "id": "cave_bat_heroic",
+      "nom": "Chauve-souris des Cavernes Héroïque",
+      "level": 53,
+      "famille": "Beast",
+      "isBoss": false,
+      "palier": 11,
+      "stats": {
+        "PV": 350,
+        "AttMin": 35,
+        "AttMax": 50,
+        "CritPct": 13,
+        "CritDmg": 175,
+        "Armure": 50,
+        "Vitesse": 1.8,
+        "Precision": 110,
+        "Esquive": 25
+      },
+      "questItemId": "bat_fang_heroic"
+    },
+    {
+      "id": "bat_matriarch_heroic",
+      "nom": "Matriarche des Cavernes Héroïque",
+      "level": 55,
+      "famille": "Beast",
+      "isBoss": true,
+      "palier": 11,
+      "stats": {
+        "PV": 2000,
+        "AttMin": 75,
+        "AttMax": 110,
+        "CritPct": 17,
+        "CritDmg": 175,
+        "Armure": 200,
+        "Vitesse": 2.0,
+        "Precision": 120,
+        "Esquive": 30
+      },
+      "abilities": [
+        {
+          "id": "sonic_screech_heroic",
+          "name": "Cri Sonique",
+          "cooldown": 12,
+          "chance": 0.5,
+          "effects": [
+            {
+              "type": "debuff",
+              "debuffType": "stat_modifier",
+              "id": "screech_armor_down_heroic",
+              "name": "Armure brisée (H)",
+              "duration": 10,
+              "statMods": [
+                {
+                  "stat": "Armure",
+                  "modifier": "multiplicative",
+                  "value": 0.75
+                }
+              ]
+            },
+            {
+              "type": "debuff",
+              "debuffType": "stat_modifier",
+              "id": "screech_precision_down_heroic",
+              "name": "Désorienté (H)",
+              "duration": 10,
+              "statMods": [
+                {
+                  "stat": "Precision",
+                  "modifier": "multiplicative",
+                  "value": 0.80
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "yeti_chieftain_heroic",
+      "nom": "Chef de Clan Yéti Héroïque",
+      "level": 58,
+      "famille": "Giant",
+      "isBoss": true,
+      "palier": 12,
+      "stats": {
+        "PV": 6000,
+        "AttMin": 125,
+        "AttMax": 175,
+        "CritPct": 13,
+        "CritDmg": 175,
+        "Armure": 750,
+        "Vitesse": 3.2,
+        "Precision": 125,
+        "Esquive": 20
+      },
+      "abilities": [
+        {
+          "id": "seismic_slam_heroic",
+          "name": "Frappe Sismique",
+          "cooldown": 15,
+          "chance": 0.4,
+          "effects": [
+            {
+              "type": "damage",
+              "damageType": "physical",
+              "multiplier": 1.8
+            },
+            {
+              "type": "debuff",
+              "debuffType": "cc",
+              "id": "slam_stun_heroic",
+              "name": "Assommé (H)",
+              "duration": 3,
+              "ccType": "stun"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "inferno_elemental_lord_heroic",
+      "nom": "Seigneur Élémentaire des Cendres Héroïque",
+      "level": 61,
+      "famille": "Elemental",
+      "isBoss": true,
+      "palier": 13,
+      "stats": {
+        "PV": 8000,
+        "AttMin": 225,
+        "AttMax": 275,
+        "CritPct": 15,
+        "CritDmg": 175,
+        "Armure": 900,
+        "Vitesse": 2.7,
+        "Precision": 130,
+        "Esquive": 22
+      },
+      "abilities": [
+        {
+          "id": "firestorm_heroic",
+          "name": "Tempête de Feu",
+          "cooldown": 15,
+          "chance": 0.5,
+          "effects": [
+            {
+              "type": "damage",
+              "damageType": "fire",
+              "multiplier": 1.2
+            },
+            {
+              "type": "debuff",
+              "debuffType": "dot",
+              "id": "immolation_dot_heroic",
+              "name": "Immolation (H)",
+              "duration": 9,
+              "damageType": "fire",
+              "totalDamage": {
+                "source": "base_value",
+                "multiplier": 200
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "ancient_dryad_matriarch_heroic",
+      "nom": "Matriarche Dryade Ancienne Héroïque",
+      "level": 64,
+      "famille": "Fey",
+      "isBoss": true,
+      "palier": 14,
+      "stats": {
+        "PV": 12000,
+        "AttMin": 300,
+        "AttMax": 375,
+        "CritPct": 20,
+        "CritDmg": 185,
+        "Armure": 1250,
+        "Vitesse": 2.4,
+        "Precision": 135,
+        "Esquive": 28
+      },
+      "abilities": [
+        {
+          "id": "thornbark_heroic",
+          "name": "Écorce d'Épines",
+          "cooldown": 20,
+          "chance": 0.4,
+          "effects": [
+            {
+              "type": "buff",
+              "buffType": "stat_modifier",
+              "id": "barkskin_buff_heroic",
+              "name": "Écorcefer (H)",
+              "duration": 12,
+              "statMods": [
+                {
+                  "stat": "Armure",
+                  "modifier": "multiplicative",
+                  "value": 2.50
+                }
+              ]
+            },
+            {
+              "type": "buff",
+              "buffType": "damage_reflection",
+              "id": "thorns_buff_heroic",
+              "name": "Épines (H)",
+              "duration": 12,
+              "reflectionValue": 0.30
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "void_cultist_leader_heroic",
+      "nom": "Chef de Culte du Vide Héroïque",
+      "level": 67,
+      "famille": "Humanoid",
+      "isBoss": true,
+      "palier": 15,
+      "stats": {
+        "PV": 18000,
+        "AttMin": 350,
+        "AttMax": 425,
+        "CritPct": 17,
+        "CritDmg": 175,
+        "Armure": 1750,
+        "Vitesse": 2.8,
+        "Precision": 140,
+        "Esquive": 24
+      },
+      "abilities": [
+        {
+          "id": "voids_embrace_heroic",
+          "name": "Étreinte du Vide",
+          "cooldown": 12,
+          "chance": 0.6,
+          "effects": [
+            {
+              "type": "debuff",
+              "debuffType": "vulnerability",
+              "id": "shadow_vuln_heroic",
+              "name": "Vulnérabilité à l'Ombre (H)",
+              "duration": 8,
+              "damageType": "shadow",
+              "multiplier": 1.25
+            },
+            {
+              "type": "damage",
+              "damageType": "shadow",
+              "multiplier": 1.3
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "void_priest_heroic",
+      "nom": "Prêtre du Vide Héroïque",
+      "level": 67,
+      "famille": "Humanoid",
+      "isBoss": true,
+      "palier": 15,
+      "stats": {
+        "PV": 19000,
+        "AttMin": 375,
+        "AttMax": 450,
+        "CritPct": 19,
+        "CritDmg": 185,
+        "Armure": 1900,
+        "Vitesse": 2.6,
+        "Precision": 142,
+        "Esquive": 26
+      },
+      "abilities": [
+        {
+          "id": "eternal_torment_heroic",
+          "name": "Tourment Éternel",
+          "cooldown": 15,
+          "chance": 0.5,
+          "effects": [
+            {
+              "type": "debuff",
+              "debuffType": "dot",
+              "id": "mind_flay_dot_heroic",
+              "name": "Fouet mental (H)",
+              "duration": 9,
+              "damageType": "shadow",
+              "totalDamage": {
+                "source": "base_value",
+                "multiplier": 250
+              }
+            },
+            {
+              "type": "debuff",
+              "debuffType": "stat_modifier",
+              "id": "power_drain_heroic",
+              "name": "Puissance drainée (H)",
+              "duration": 9,
+              "statMods": [
+                {
+                  "stat": "AttMin",
+                  "modifier": "multiplicative",
+                  "value": 0.85
+                },
+                {
+                  "stat": "AttMax",
+                  "modifier": "multiplicative",
+                  "value": 0.85
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "icebound_warlord_heroic",
+      "nom": "Seigneur de Guerre Englacé Héroïque",
+      "level": 70,
+      "famille": "Humanoid",
+      "isBoss": true,
+      "palier": 16,
+      "stats": {
+        "PV": 25000,
+        "AttMin": 475,
+        "AttMax": 575,
+        "CritPct": 20,
+        "CritDmg": 175,
+        "Armure": 2500,
+        "Vitesse": 3.2,
+        "Precision": 145,
+        "Esquive": 20
+      },
+      "abilities": [
+        {
+          "id": "glacial_annihilation_heroic",
+          "name": "Anéantissement Glacial",
+          "cooldown": 12,
+          "chance": 0.5,
+          "effects": [
+            {
+              "type": "damage",
+              "damageType": "physical",
+              "multiplier": 0.75
+            },
+            {
+              "type": "damage",
+              "damageType": "ice",
+              "multiplier": 0.75
+            },
+            {
+              "type": "debuff",
+              "debuffType": "stat_modifier",
+              "id": "shattering_armor_down_heroic",
+              "name": "Armure fracassée (H)",
+              "duration": 12,
+              "statMods": [
+                {
+                  "stat": "Armure",
+                  "modifier": "multiplicative",
+                  "value": 0.65
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "fire_giant_champion_heroic",
+      "nom": "Champion Géant de Feu Héroïque",
+      "level": 73,
+      "famille": "Giant",
+      "isBoss": true,
+      "palier": 17,
+      "stats": {
+        "PV": 35000,
+        "AttMin": 600,
+        "AttMax": 700,
+        "CritPct": 15,
+        "CritDmg": 175,
+        "Armure": 3500,
+        "Vitesse": 3.4,
+        "Precision": 150,
+        "Esquive": 19
+      },
+      "abilities": [
+        {
+          "id": "ashen_mark_heroic",
+          "name": "Marque Cendrée",
+          "cooldown": 16,
+          "chance": 0.4,
+          "effects": [
+            {
+              "type": "damage",
+              "damageType": "fire",
+              "multiplier": 1.8
+            },
+            {
+              "type": "debuff",
+              "debuffType": "healing_received_modifier",
+              "id": "mortal_wound_heroic",
+              "name": "Marque Cendrée (H)",
+              "duration": 10,
+              "multiplier": 0.50
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "guardian_of_the_grove_heroic",
+      "nom": "Gardien du Bosquet Héroïque",
+      "level": 76,
+      "famille": "Fey",
+      "isBoss": true,
+      "palier": 18,
+      "stats": {
+        "PV": 45000,
+        "AttMin": 750,
+        "AttMax": 900,
+        "CritPct": 23,
+        "CritDmg": 185,
+        "Armure": 4000,
+        "Vitesse": 2.6,
+        "Precision": 155,
+        "Esquive": 30
+      },
+      "abilities": [
+        {
+          "id": "primordial_grasp_heroic",
+          "name": "Emprise Primordiale",
+          "cooldown": 18,
+          "chance": 0.4,
+          "effects": [
+            {
+              "type": "debuff",
+              "debuffType": "cc",
+              "id": "grasp_root_heroic",
+              "name": "Enraciné (H)",
+              "duration": 4,
+              "ccType": "stun"
+            },
+            {
+              "type": "debuff",
+              "debuffType": "dot",
+              "id": "grasp_dot_heroic",
+              "name": "Ronces (H)",
+              "duration": 4,
+              "damageType": "nature",
+              "totalDamage": {
+                "source": "base_value",
+                "multiplier": 300
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "spectral_overlord_heroic",
+      "nom": "Souverain Spectral Héroïque",
+      "level": 79,
+      "famille": "Undead",
+      "isBoss": true,
+      "palier": 19,
+      "stats": {
+        "PV": 55000,
+        "AttMin": 950,
+        "AttMax": 1100,
+        "CritPct": 27,
+        "CritDmg": 205,
+        "Armure": 4500,
+        "Vitesse": 2.0,
+        "Precision": 160,
+        "Esquive": 42
+      },
+      "abilities": [
+        {
+          "id": "feast_of_souls_heroic",
+          "name": "Festin d'Âmes",
+          "cooldown": 20,
+          "chance": 0.5,
+          "effects": [
+            {
+              "type": "debuff",
+              "debuffType": "dot",
+              "id": "soul_drain_dot_heroic",
+              "name": "Drain d'âme (H)",
+              "duration": 8,
+              "damageType": "shadow",
+              "totalDamage": {
+                "source": "base_value",
+                "multiplier": 400
+              }
+            },
+            {
+              "type": "buff",
+              "buffType": "hot",
+              "id": "soul_feast_hot_heroic",
+              "name": "Festin (H)",
+              "duration": 8,
+              "totalHeal": {
+                "source": "max_health_percentage",
+                "percentage": 0.05
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "boreal_crusader_heroic",
+      "nom": "Croisé Boréal Héroïque",
+      "level": 82,
+      "famille": "Humanoid",
+      "isBoss": true,
+      "palier": 20,
+      "stats": {
+        "PV": 70000,
+        "AttMin": 1150,
+        "AttMax": 1350,
+        "CritPct": 20,
+        "CritDmg": 175,
+        "Armure": 7500,
+        "Vitesse": 3.2,
+        "Precision": 165,
+        "Esquive": 24
+      },
+      "abilities": [
+        {
+          "id": "holy_judgment_heroic",
+          "name": "Jugement Sacré",
+          "cooldown": 15,
+          "chance": 0.5,
+          "effects": [
+            {
+              "type": "damage",
+              "damageType": "holy",
+              "multiplier": 1.6
+            },
+            {
+              "type": "buff",
+              "buffType": "stat_modifier",
+              "id": "judgment_buff_heroic",
+              "name": "Jugement (H)",
+              "duration": 10,
+              "statMods": [
+                {
+                  "stat": "Vitesse",
+                  "modifier": "multiplicative_add",
+                  "value": -0.20
+                },
+                {
+                  "stat": "Precision",
+                  "modifier": "multiplicative",
+                  "value": 1.20
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "ashwing_matriarch_heroic",
+      "nom": "Matriarche Aile-de-Cendre Héroïque",
+      "level": 85,
+      "famille": "Beast",
+      "isBoss": true,
+      "palier": 21,
+      "stats": {
+        "PV": 80000,
+        "AttMin": 1400,
+        "AttMax": 1600,
+        "CritPct": 30,
+        "CritDmg": 205,
+        "Armure": 8000,
+        "Vitesse": 2.2,
+        "Precision": 170,
+        "Esquive": 40
+      },
+      "abilities": [
+        {
+          "id": "ashen_tempest_heroic",
+          "name": "Tempête de Cendres",
+          "cooldown": 18,
+          "chance": 0.4,
+          "effects": [
+            {
+              "type": "damage",
+              "damageType": "physical",
+              "multiplier": 1.5
+            },
+            {
+              "type": "debuff",
+              "debuffType": "stat_modifier",
+              "id": "tempest_debuff_heroic",
+              "name": "Aveuglé (H)",
+              "duration": 8,
+              "statMods": [
+                {
+                  "stat": "Precision",
+                  "modifier": "multiplicative",
+                  "value": 0.70
+                },
+                {
+                  "stat": "CritPct",
+                  "modifier": "multiplicative",
+                  "value": 0.70
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "colossus_of_the_grove_heroic",
+      "nom": "Colosse du Bosquet Héroïque",
+      "level": 88,
+      "famille": "Construct",
+      "isBoss": true,
+      "palier": 22,
+      "stats": {
+        "PV": 120000,
+        "AttMin": 1750,
+        "AttMax": 2000,
+        "CritPct": 15,
+        "CritDmg": 175,
+        "Armure": 12500,
+        "Vitesse": 4.2,
+        "Precision": 175,
+        "Esquive": 17
+      },
+      "abilities": [
+        {
+          "id": "colossal_slam_heroic",
+          "name": "Frappe Colossale",
+          "cooldown": 20,
+          "chance": 0.4,
+          "effects": [
+            {
+              "type": "damage",
+              "damageType": "physical",
+              "multiplier": 2.0
+            },
+            {
+              "type": "debuff",
+              "debuffType": "stat_modifier",
+              "id": "colossal_slow_heroic",
+              "name": "Écrasé (H)",
+              "duration": 10,
+              "statMods": [
+                {
+                  "stat": "Vitesse",
+                  "modifier": "multiplicative",
+                  "value": 1.50
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "ancient_tomb_protector_heroic",
+      "nom": "Protecteur de Tombe Ancien Héroïque",
+      "level": 91,
+      "famille": "Construct",
+      "isBoss": true,
+      "palier": 23,
+      "stats": {
+        "PV": 150000,
+        "AttMin": 2100,
+        "AttMax": 2400,
+        "CritPct": 13,
+        "CritDmg": 175,
+        "Armure": 17500,
+        "Vitesse": 4.5,
+        "Precision": 180,
+        "Esquive": 16
+      },
+      "abilities": [
+        {
+          "id": "immutable_form_heroic",
+          "name": "Forme Immuable",
+          "cooldown": 30,
+          "chance": 0.3,
+          "effects": [
+            {
+              "type": "buff",
+              "buffType": "stat_modifier",
+              "id": "stone_form_buff_heroic",
+              "name": "Forme de pierre (H)",
+              "duration": 10,
+              "statMods": [
+                {
+                  "stat": "Armure",
+                  "modifier": "multiplicative",
+                  "value": 4.0
+                }
+              ]
+            },
+            {
+              "type": "buff",
+              "buffType": "hot",
+              "id": "stone_regen_heroic",
+              "name": "Régénération (H)",
+              "duration": 10,
+              "totalHeal": {
+                "source": "max_health_percentage",
+                "percentage": 0.15
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "grove_protector",
+      "nom": "Grove Protector",
+      "level": 14,
+      "famille": "Fey",
+      "isBoss": true,
+      "palier": 4,
+      "stats": {
+        "PV": 1250,
+        "AttMin": 62,
+        "AttMax": 78,
+        "CritPct": 16,
+        "CritDmg": 160,
+        "Armure": 260,
+        "Vitesse": 2.3,
+        "Precision": 88,
+        "Esquive": 20
+      },
+      "abilities": [
+        {
+          "id": "healing_touch",
+          "name": "Healing Touch",
+          "cooldown": 25,
+          "chance": 0.4,
+          "effects": [
+            {
+              "type": "buff",
+              "buffType": "hot",
+              "id": "healing_touch_hot",
+              "name": "Healing Touch",
+              "duration": 10,
+              "totalHeal": {
+                "source": "max_health_percentage",
+                "percentage": 0.10
+              }
+            }
+          ]
+        }
+      ],
+      "specificLootTable": [
+        "set_shadow_shroud_mask",
+        "set_shadow_shroud_tunic"
+      ]
+    },
+    {
+      "id": "grove_protector_heroic",
+      "nom": "Grove Protector Heroic",
+      "level": 64,
+      "famille": "Fey",
+      "isBoss": true,
+      "palier": 14,
+      "stats": {
+        "PV": 12500,
+        "AttMin": 310,
+        "AttMax": 385,
+        "CritPct": 22,
+        "CritDmg": 185,
+        "Armure": 1300,
+        "Vitesse": 2.3,
+        "Precision": 138,
+        "Esquive": 30
+      },
+      "abilities": [
+        {
+          "id": "healing_touch_heroic",
+          "name": "Healing Touch Heroic",
+          "cooldown": 25,
+          "chance": 0.4,
+          "effects": [
+            {
+              "type": "buff",
+              "buffType": "hot",
+              "id": "healing_touch_hot_heroic",
+              "name": "Healing Touch (H)",
+              "duration": 10,
+              "totalHeal": {
+                "source": "max_health_percentage",
+                "percentage": 0.15
+              }
+            },
+            {
+              "type": "buff",
+              "buffType": "stat_modifier",
+              "id": "healing_touch_buff_heroic",
+              "name": "Regrowth (H)",
+              "duration": 10,
+              "statMods": [
+                {
+                  "stat": "Vitesse",
+                  "modifier": "multiplicative_add",
+                  "value": -0.15
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "frozen_reaver",
+      "nom": "Frozen Reaver",
+      "level": 20,
+      "famille": "Humanoid",
+      "isBoss": true,
+      "palier": 6,
+      "stats": {
+        "PV": 2200,
+        "AttMin": 95,
+        "AttMax": 115,
+        "CritPct": 17,
+        "CritDmg": 150,
+        "Armure": 520,
+        "Vitesse": 3.1,
+        "Precision": 98,
+        "Esquive": 12
+      },
+      "abilities": [
+        {
+          "id": "frost_nova",
+          "name": "Frost Nova",
+          "cooldown": 15,
+          "chance": 0.4,
+          "effects": [
+            {
+              "type": "damage",
+              "damageType": "ice",
+              "multiplier": 1.2
+            },
+            {
+              "type": "debuff",
+              "debuffType": "cc",
+              "id": "frost_nova_stun",
+              "name": "Frozen",
+              "duration": 2,
+              "ccType": "stun"
+            }
+          ]
+        }
+      ],
+      "specificLootTable": [
+        "rep_silver_vanguard_helm",
+        "rep_silver_vanguard_greataxe"
+      ]
+    },
+    {
+      "id": "frozen_reaver_heroic",
+      "nom": "Frozen Reaver Heroic",
+      "level": 70,
+      "famille": "Humanoid",
+      "isBoss": true,
+      "palier": 16,
+      "stats": {
+        "PV": 26000,
+        "AttMin": 485,
+        "AttMax": 585,
+        "CritPct": 22,
+        "CritDmg": 175,
+        "Armure": 2600,
+        "Vitesse": 3.1,
+        "Precision": 148,
+        "Esquive": 22
+      },
+      "abilities": [
+        {
+          "id": "frost_nova_heroic",
+          "name": "Frost Nova Heroic",
+          "cooldown": 15,
+          "chance": 0.4,
+          "effects": [
+            {
+              "type": "damage",
+              "damageType": "ice",
+              "multiplier": 1.5
+            },
+            {
+              "type": "debuff",
+              "debuffType": "cc",
+              "id": "frost_nova_stun_heroic",
+              "name": "Frozen (H)",
+              "duration": 3,
+              "ccType": "stun"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "magma_destroyer",
+      "nom": "Magma Destroyer",
+      "level": 23,
+      "famille": "Giant",
+      "isBoss": true,
+      "palier": 7,
+      "stats": {
+        "PV": 3100,
+        "AttMin": 120,
+        "AttMax": 140,
+        "CritPct": 12,
+        "CritDmg": 150,
+        "Armure": 750,
+        "Vitesse": 3.3,
+        "Precision": 105,
+        "Esquive": 11
+      },
+      "abilities": [
+        {
+          "id": "lava_burst",
+          "name": "Lava Burst",
+          "cooldown": 12,
+          "chance": 0.5,
+          "effects": [
+            {
+              "type": "damage",
+              "damageType": "fire",
+              "multiplier": 1.8
+            }
+          ]
+        }
+      ],
+      "specificLootTable": [
+        "rep_magma_callers_cowl",
+        "rep_magma_callers_staff"
+      ]
+    },
+    {
+      "id": "magma_destroyer_heroic",
+      "nom": "Magma Destroyer Heroic",
+      "level": 73,
+      "famille": "Giant",
+      "isBoss": true,
+      "palier": 17,
+      "stats": {
+        "PV": 36000,
+        "AttMin": 610,
+        "AttMax": 710,
+        "CritPct": 17,
+        "CritDmg": 175,
+        "Armure": 3600,
+        "Vitesse": 3.3,
+        "Precision": 155,
+        "Esquive": 21
+      },
+      "abilities": [
+        {
+          "id": "lava_burst_heroic",
+          "name": "Lava Burst Heroic",
+          "cooldown": 12,
+          "chance": 0.5,
+          "effects": [
+            {
+              "type": "damage",
+              "damageType": "fire",
+              "multiplier": 2.0
+            },
+            {
+              "type": "debuff",
+              "debuffType": "dot",
+              "id": "lava_dot_heroic",
+              "name": "Burning (H)",
+              "duration": 6,
+              "damageType": "fire",
+              "totalDamage": {
+                "source": "base_value",
+                "multiplier": 150
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "sylvan_sentinel",
+      "nom": "Sylvan Sentinel",
+      "level": 26,
+      "famille": "Fey",
+      "isBoss": true,
+      "palier": 8,
+      "stats": {
+        "PV": 4000,
+        "AttMin": 150,
+        "AttMax": 180,
+        "CritPct": 20,
+        "CritDmg": 160,
+        "Armure": 850,
+        "Vitesse": 2.5,
+        "Precision": 110,
+        "Esquive": 22
+      },
+      "abilities": [
+        {
+          "id": "natures_wrath",
+          "name": "Nature's Wrath",
+          "cooldown": 18,
+          "chance": 0.4,
+          "effects": [
+            {
+              "type": "damage",
+              "damageType": "nature",
+              "multiplier": 1.5
+            },
+            {
+              "type": "debuff",
+              "debuffType": "vulnerability",
+              "id": "nature_vuln",
+              "name": "Nature Vulnerability",
+              "duration": 10,
+              "damageType": "nature",
+              "multiplier": 1.10
+            }
+          ]
+        }
+      ],
+      "specificLootTable": [
+        "rep_silent_path_mask",
+        "rep_silent_path_daggers"
+      ]
+    },
+    {
+      "id": "sylvan_sentinel_heroic",
+      "nom": "Sylvan Sentinel Heroic",
+      "level": 76,
+      "famille": "Fey",
+      "isBoss": true,
+      "palier": 18,
+      "stats": {
+        "PV": 47000,
+        "AttMin": 760,
+        "AttMax": 910,
+        "CritPct": 25,
+        "CritDmg": 185,
+        "Armure": 4200,
+        "Vitesse": 2.5,
+        "Precision": 160,
+        "Esquive": 32
+      },
+      "abilities": [
+        {
+          "id": "natures_wrath_heroic",
+          "name": "Nature's Wrath Heroic",
+          "cooldown": 18,
+          "chance": 0.4,
+          "effects": [
+            {
+              "type": "damage",
+              "damageType": "nature",
+              "multiplier": 1.8
+            },
+            {
+              "type": "debuff",
+              "debuffType": "vulnerability",
+              "id": "nature_vuln_heroic",
+              "name": "Nature Vulnerability (H)",
+              "duration": 10,
+              "damageType": "nature",
+              "multiplier": 1.20
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "nether_lich",
+      "nom": "Nether Lich",
+      "level": 29,
+      "famille": "Undead",
+      "isBoss": true,
+      "palier": 9,
+      "stats": {
+        "PV": 4800,
+        "AttMin": 190,
+        "AttMax": 220,
+        "CritPct": 24,
+        "CritDmg": 180,
+        "Armure": 950,
+        "Vitesse": 1.9,
+        "Precision": 115,
+        "Esquive": 34
+      },
+      "abilities": [
+        {
+          "id": "shadow_bolt_volley",
+          "name": "Shadow Bolt Volley",
+          "cooldown": 10,
+          "chance": 0.6,
+          "effects": [
+            {
+              "type": "damage",
+              "damageType": "shadow",
+              "multiplier": 1.4
+            }
+          ]
+        }
+      ],
+      "specificLootTable": [
+        "rep_faithsworn_diadem",
+        "rep_faithsworn_mace"
+      ]
+    },
+    {
+      "id": "nether_lich_heroic",
+      "nom": "Nether Lich Heroic",
+      "level": 79,
+      "famille": "Undead",
+      "isBoss": true,
+      "palier": 19,
+      "stats": {
+        "PV": 57000,
+        "AttMin": 960,
+        "AttMax": 1110,
+        "CritPct": 29,
+        "CritDmg": 205,
+        "Armure": 4700,
+        "Vitesse": 1.9,
+        "Precision": 165,
+        "Esquive": 44
+      },
+      "abilities": [
+        {
+          "id": "shadow_bolt_volley_heroic",
+          "name": "Shadow Bolt Volley Heroic",
+          "cooldown": 10,
+          "chance": 0.6,
+          "effects": [
+            {
+              "type": "damage",
+              "damageType": "shadow",
+              "multiplier": 1.7
+            },
+            {
+              "type": "debuff",
+              "debuffType": "stat_modifier",
+              "id": "shadow_curse_heroic",
+              "name": "Shadow Curse (H)",
+              "duration": 8,
+              "statMods": [
+                {
+                  "stat": "CritDmg",
+                  "modifier": "multiplicative",
+                  "value": 0.80
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "tundra_king",
+      "nom": "Tundra King",
+      "level": 32,
+      "famille": "Humanoid",
+      "isBoss": true,
+      "palier": 10,
+      "stats": {
+        "PV": 6000,
+        "AttMin": 220,
+        "AttMax": 260,
+        "CritPct": 17,
+        "CritDmg": 150,
+        "Armure": 1600,
+        "Vitesse": 3.1,
+        "Precision": 120,
+        "Esquive": 16
+      },
+      "abilities": [
+        {
+          "id": "icy_cleave",
+          "name": "Icy Cleave",
+          "cooldown": 10,
+          "chance": 0.5,
+          "effects": [
+            {
+              "type": "damage",
+              "damageType": "ice",
+              "multiplier": 1.5
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "tundra_king_heroic",
+      "nom": "Tundra King Heroic",
+      "level": 82,
+      "famille": "Humanoid",
+      "isBoss": true,
+      "palier": 20,
+      "stats": {
+        "PV": 72000,
+        "AttMin": 1160,
+        "AttMax": 1360,
+        "CritPct": 22,
+        "CritDmg": 175,
+        "Armure": 7700,
+        "Vitesse": 3.1,
+        "Precision": 170,
+        "Esquive": 26
+      },
+      "abilities": [
+        {
+          "id": "icy_cleave_heroic",
+          "name": "Icy Cleave Heroic",
+          "cooldown": 10,
+          "chance": 0.5,
+          "effects": [
+            {
+              "type": "damage",
+              "damageType": "ice",
+              "multiplier": 1.8
+            },
+            {
+              "type": "debuff",
+              "debuffType": "stat_modifier",
+              "id": "cleave_slow_heroic",
+              "name": "Chilled (H)",
+              "duration": 6,
+              "statMods": [
+                {
+                  "stat": "Vitesse",
+                  "modifier": "multiplicative",
+                  "value": 1.25
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "emberwing_scion",
+      "nom": "Emberwing Scion",
+      "level": 35,
+      "famille": "Beast",
+      "isBoss": true,
+      "palier": 11,
+      "stats": {
+        "PV": 6800,
+        "AttMin": 265,
+        "AttMax": 305,
+        "CritPct": 27,
+        "CritDmg": 180,
+        "Armure": 1700,
+        "Vitesse": 2.1,
+        "Precision": 125,
+        "Esquive": 32
+      },
+      "abilities": [
+        {
+          "id": "fire_breath",
+          "name": "Fire Breath",
+          "cooldown": 12,
+          "chance": 0.5,
+          "effects": [
+            {
+              "type": "debuff",
+              "debuffType": "dot",
+              "id": "fire_breath_dot",
+              "name": "Fire Breath",
+              "duration": 9,
+              "damageType": "fire",
+              "totalDamage": {
+                "source": "base_value",
+                "multiplier": 120
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "emberwing_scion_heroic",
+      "nom": "Emberwing Scion Heroic",
+      "level": 85,
+      "famille": "Beast",
+      "isBoss": true,
+      "palier": 21,
+      "stats": {
+        "PV": 82000,
+        "AttMin": 1410,
+        "AttMax": 1610,
+        "CritPct": 32,
+        "CritDmg": 205,
+        "Armure": 8200,
+        "Vitesse": 2.1,
+        "Precision": 175,
+        "Esquive": 42
+      },
+      "abilities": [
+        {
+          "id": "fire_breath_heroic",
+          "name": "Fire Breath Heroic",
+          "cooldown": 12,
+          "chance": 0.5,
+          "effects": [
+            {
+              "type": "debuff",
+              "debuffType": "dot",
+              "id": "fire_breath_dot_heroic",
+              "name": "Fire Breath (H)",
+              "duration": 9,
+              "damageType": "fire",
+              "totalDamage": {
+                "source": "base_value",
+                "multiplier": 250
+              }
+            },
+            {
+              "type": "debuff",
+              "debuffType": "vulnerability",
+              "id": "fire_vuln_heroic",
+              "name": "Fire Vulnerability (H)",
+              "duration": 9,
+              "damageType": "fire",
+              "multiplier": 1.15
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "emerald_titan",
+      "nom": "Emerald Titan",
+      "level": 38,
+      "famille": "Construct",
+      "isBoss": true,
+      "palier": 12,
+      "stats": {
+        "PV": 10000,
+        "AttMin": 330,
+        "AttMax": 380,
+        "CritPct": 12,
+        "CritDmg": 150,
+        "Armure": 2600,
+        "Vitesse": 4.1,
+        "Precision": 130,
+        "Esquive": 9
+      },
+      "abilities": [
+        {
+          "id": "stone_shatter",
+          "name": "Stone Shatter",
+          "cooldown": 15,
+          "chance": 0.4,
+          "effects": [
+            {
+              "type": "damage",
+              "damageType": "physical",
+              "multiplier": 1.6
+            },
+            {
+              "type": "debuff",
+              "debuffType": "stat_modifier",
+              "id": "shatter_armor_down",
+              "name": "Shattered Armor",
+              "duration": 10,
+              "statMods": [
+                {
+                  "stat": "Armure",
+                  "modifier": "multiplicative",
+                  "value": 0.85
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "emerald_titan_heroic",
+      "nom": "Emerald Titan Heroic",
+      "level": 88,
+      "famille": "Construct",
+      "isBoss": true,
+      "palier": 22,
+      "stats": {
+        "PV": 122000,
+        "AttMin": 1760,
+        "AttMax": 2010,
+        "CritPct": 17,
+        "CritDmg": 175,
+        "Armure": 12700,
+        "Vitesse": 4.1,
+        "Precision": 180,
+        "Esquive": 19
+      },
+      "abilities": [
+        {
+          "id": "stone_shatter_heroic",
+          "name": "Stone Shatter Heroic",
+          "cooldown": 15,
+          "chance": 0.4,
+          "effects": [
+            {
+              "type": "damage",
+              "damageType": "physical",
+              "multiplier": 2.2
+            },
+            {
+              "type": "debuff",
+              "debuffType": "stat_modifier",
+              "id": "shatter_armor_down_heroic",
+              "name": "Shattered Armor (H)",
+              "duration": 10,
+              "statMods": [
+                {
+                  "stat": "Armure",
+                  "modifier": "multiplicative",
+                  "value": 0.70
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "crypt_lord",
+      "nom": "Crypt Lord",
+      "level": 41,
+      "famille": "Construct",
+      "isBoss": true,
+      "palier": 13,
+      "stats": {
+        "PV": 12500,
+        "AttMin": 385,
+        "AttMax": 440,
+        "CritPct": 10,
+        "CritDmg": 150,
+        "Armure": 3600,
+        "Vitesse": 4.4,
+        "Precision": 135,
+        "Esquive": 8
+      },
+      "abilities": [
+        {
+          "id": "cursed_ground",
+          "name": "Cursed Ground",
+          "cooldown": 20,
+          "chance": 0.3,
+          "effects": [
+            {
+              "type": "debuff",
+              "debuffType": "dot",
+              "id": "cursed_ground_dot",
+              "name": "Cursed Ground",
+              "duration": 12,
+              "damageType": "shadow",
+              "totalDamage": {
+                "source": "base_value",
+                "multiplier": 180
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "crypt_lord_heroic",
+      "nom": "Crypt Lord Heroic",
+      "level": 91,
+      "famille": "Construct",
+      "isBoss": true,
+      "palier": 23,
+      "stats": {
+        "PV": 152000,
+        "AttMin": 2110,
+        "AttMax": 2410,
+        "CritPct": 15,
+        "CritDmg": 175,
+        "Armure": 17700,
+        "Vitesse": 4.4,
+        "Precision": 185,
+        "Esquive": 18
+      },
+      "abilities": [
+        {
+          "id": "cursed_ground_heroic",
+          "name": "Cursed Ground Heroic",
+          "cooldown": 20,
+          "chance": 0.3,
+          "effects": [
+            {
+              "type": "debuff",
+              "debuffType": "dot",
+              "id": "cursed_ground_dot_heroic",
+              "name": "Cursed Ground (H)",
+              "duration": 12,
+              "damageType": "shadow",
+              "totalDamage": {
+                "source": "base_value",
+                "multiplier": 300
+              }
+            },
+            {
+              "type": "debuff",
+              "debuffType": "healing_received_modifier",
+              "id": "curse_healing_down_heroic",
+              "name": "Cursed (H)",
+              "duration": 12,
+              "multiplier": 0.75
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "glacial_behemoth",
+      "nom": "Glacial Behemoth",
+      "level": 40,
+      "famille": "Giant",
+      "isBoss": true,
+      "palier": 14,
+      "stats": {
+        "PV": 13000,
+        "AttMin": 370,
+        "AttMax": 415,
+        "CritPct": 16,
+        "CritDmg": 180,
+        "Armure": 2600,
+        "Vitesse": 3.1,
+        "Precision": 122,
+        "Esquive": 17
+      },
+      "abilities": [
+        {
+          "id": "glacial_slam",
+          "name": "Glacial Slam",
+          "cooldown": 18,
+          "chance": 0.4,
+          "effects": [
+            {
+              "type": "damage",
+              "damageType": "ice",
+              "multiplier": 1.6
+            },
+            {
+              "type": "debuff",
+              "debuffType": "cc",
+              "id": "glacial_stun",
+              "name": "Glacial Stun",
+              "duration": 3,
+              "ccType": "stun"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "glacial_behemoth_heroic",
+      "nom": "Glacial Behemoth Heroic",
+      "level": 90,
+      "famille": "Giant",
+      "isBoss": true,
+      "palier": 24,
+      "stats": {
+        "PV": 132000,
+        "AttMin": 2010,
+        "AttMax": 2260,
+        "CritPct": 21,
+        "CritDmg": 205,
+        "Armure": 13200,
+        "Vitesse": 3.1,
+        "Precision": 192,
+        "Esquive": 27
+      },
+      "abilities": [
+        {
+          "id": "glacial_slam_heroic",
+          "name": "Glacial Slam Heroic",
+          "cooldown": 18,
+          "chance": 0.4,
+          "effects": [
+            {
+              "type": "damage",
+              "damageType": "ice",
+              "multiplier": 2.0
+            },
+            {
+              "type": "debuff",
+              "debuffType": "cc",
+              "id": "glacial_stun_heroic",
+              "name": "Glacial Stun (H)",
+              "duration": 4,
+              "ccType": "stun"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "icecrown_sentinel",
+      "nom": "Icecrown Sentinel",
+      "level": 40,
+      "famille": "Construct",
+      "isBoss": true,
+      "palier": 14,
+      "stats": {
+        "PV": 12500,
+        "AttMin": 365,
+        "AttMax": 410,
+        "CritPct": 15,
+        "CritDmg": 180,
+        "Armure": 2700,
+        "Vitesse": 3.2,
+        "Precision": 121,
+        "Esquive": 16
+      },
+      "abilities": [
+        {
+          "id": "frozen_armor",
+          "name": "Frozen Armor",
+          "cooldown": 22,
+          "chance": 0.3,
+          "effects": [
+            {
+              "type": "buff",
+              "buffType": "stat_modifier",
+              "id": "frozen_armor_buff",
+              "name": "Frozen Armor",
+              "duration": 10,
+              "statMods": [
+                {
+                  "stat": "Armure",
+                  "modifier": "multiplicative",
+                  "value": 2.5
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "icecrown_sentinel_heroic",
+      "nom": "Icecrown Sentinel Heroic",
+      "level": 90,
+      "famille": "Construct",
+      "isBoss": true,
+      "palier": 24,
+      "stats": {
+        "PV": 127000,
+        "AttMin": 2060,
+        "AttMax": 2310,
+        "CritPct": 20,
+        "CritDmg": 205,
+        "Armure": 13700,
+        "Vitesse": 3.2,
+        "Precision": 191,
+        "Esquive": 26
+      },
+      "abilities": [
+        {
+          "id": "frozen_armor_heroic",
+          "name": "Frozen Armor Heroic",
+          "cooldown": 22,
+          "chance": 0.3,
+          "effects": [
+            {
+              "type": "buff",
+              "buffType": "stat_modifier",
+              "id": "frozen_armor_buff_heroic",
+              "name": "Frozen Armor (H)",
+              "duration": 10,
+              "statMods": [
+                {
+                  "stat": "Armure",
+                  "modifier": "multiplicative",
+                  "value": 3.5
+                }
+              ]
+            },
+            {
+              "type": "buff",
+              "buffType": "hot",
+              "id": "frozen_regen_heroic",
+              "name": "Frozen Regeneration (H)",
+              "duration": 10,
+              "totalHeal": {
+                "source": "max_health_percentage",
+                "percentage": 0.10
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "frostlord",
+      "nom": "Frostlord",
+      "level": 40,
+      "famille": "Humanoid",
+      "isBoss": true,
+      "palier": 14,
+      "stats": {
+        "PV": 11500,
+        "AttMin": 380,
+        "AttMax": 430,
+        "CritPct": 18,
+        "CritDmg": 180,
+        "Armure": 2400,
+        "Vitesse": 2.9,
+        "Precision": 125,
+        "Esquive": 19
+      },
+      "abilities": [
+        {
+          "id": "cone_of_cold",
+          "name": "Cone of Cold",
+          "cooldown": 15,
+          "chance": 0.5,
+          "effects": [
+            {
+              "type": "damage",
+              "damageType": "ice",
+              "multiplier": 1.4
+            },
+            {
+              "type": "debuff",
+              "debuffType": "stat_modifier",
+              "id": "cone_of_cold_slow",
+              "name": "Chilled",
+              "duration": 8,
+              "statMods": [
+                {
+                  "stat": "Vitesse",
+                  "modifier": "multiplicative",
+                  "value": 1.30
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "frostlord_heroic",
+      "nom": "Frostlord Heroic",
+      "level": 90,
+      "famille": "Humanoid",
+      "isBoss": true,
+      "palier": 24,
+      "stats": {
+        "PV": 117000,
+        "AttMin": 2110,
+        "AttMax": 2360,
+        "CritPct": 23,
+        "CritDmg": 205,
+        "Armure": 12900,
+        "Vitesse": 2.9,
+        "Precision": 195,
+        "Esquive": 29
+      },
+      "abilities": [
+        {
+          "id": "cone_of_cold_heroic",
+          "name": "Cone of Cold Heroic",
+          "cooldown": 15,
+          "chance": 0.5,
+          "effects": [
+            {
+              "type": "damage",
+              "damageType": "ice",
+              "multiplier": 1.8
+            },
+            {
+              "type": "debuff",
+              "debuffType": "stat_modifier",
+              "id": "cone_of_cold_slow_heroic",
+              "name": "Chilled (H)",
+              "duration": 8,
+              "statMods": [
+                {
+                  "stat": "Vitesse",
+                  "modifier": "multiplicative",
+                  "value": 1.50
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "rimefang",
+      "nom": "Rimefang",
+      "level": 40,
+      "famille": "Dragonkin",
+      "isBoss": true,
+      "palier": 14,
+      "stats": {
+        "PV": 12000,
+        "AttMin": 375,
+        "AttMax": 425,
+        "CritPct": 17,
+        "CritDmg": 180,
+        "Armure": 2500,
+        "Vitesse": 3.0,
+        "Precision": 124,
+        "Esquive": 18
+      },
+      "abilities": [
+        {
+          "id": "frost_breath",
+          "name": "Frost Breath",
+          "cooldown": 16,
+          "chance": 0.4,
+          "effects": [
+            {
+              "type": "debuff",
+              "debuffType": "dot",
+              "id": "frost_breath_dot",
+              "name": "Frost Breath",
+              "duration": 9,
+              "damageType": "ice",
+              "totalDamage": {
+                "source": "base_value",
+                "multiplier": 200
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "rimefang_heroic",
+      "nom": "Rimefang Heroic",
+      "level": 90,
+      "famille": "Dragonkin",
+      "isBoss": true,
+      "palier": 24,
+      "stats": {
+        "PV": 122000,
+        "AttMin": 2060,
+        "AttMax": 2310,
+        "CritPct": 22,
+        "CritDmg": 205,
+        "Armure": 13400,
+        "Vitesse": 3.0,
+        "Precision": 194,
+        "Esquive": 28
+      },
+      "abilities": [
+        {
+          "id": "frost_breath_heroic",
+          "name": "Frost Breath Heroic",
+          "cooldown": 16,
+          "chance": 0.4,
+          "effects": [
+            {
+              "type": "debuff",
+              "debuffType": "dot",
+              "id": "frost_breath_dot_heroic",
+              "name": "Frost Breath (H)",
+              "duration": 9,
+              "damageType": "ice",
+              "totalDamage": {
+                "source": "base_value",
+                "multiplier": 400
+              }
+            },
+            {
+              "type": "debuff",
+              "debuffType": "vulnerability",
+              "id": "frost_vuln_heroic",
+              "name": "Frost Vulnerability (H)",
+              "duration": 9,
+              "damageType": "ice",
+              "multiplier": 1.15
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "frozen_terror",
+      "nom": "Frozen Terror",
+      "level": 40,
+      "famille": "Aberration",
+      "isBoss": true,
+      "palier": 14,
+      "stats": {
+        "PV": 11000,
+        "AttMin": 385,
+        "AttMax": 435,
+        "CritPct": 19,
+        "CritDmg": 180,
+        "Armure": 2300,
+        "Vitesse": 2.8,
+        "Precision": 126,
+        "Esquive": 20
+      },
+      "abilities": [
+        {
+          "id": "touch_of_the_frozen",
+          "name": "Touch of the Frozen",
+          "cooldown": 20,
+          "chance": 0.3,
+          "effects": [
+            {
+              "type": "debuff",
+              "debuffType": "stat_modifier",
+              "id": "frozen_touch_debuff",
+              "name": "Frozen Touch",
+              "duration": 10,
+              "statMods": [
+                {
+                  "stat": "Precision",
+                  "modifier": "multiplicative",
+                  "value": 0.80
+                },
+                {
+                  "stat": "Esquive",
+                  "modifier": "multiplicative",
+                  "value": 0.80
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "frozen_terror_heroic",
+      "nom": "Frozen Terror Heroic",
+      "level": 90,
+      "famille": "Aberration",
+      "isBoss": true,
+      "palier": 24,
+      "stats": {
+        "PV": 112000,
+        "AttMin": 2160,
+        "AttMax": 2410,
+        "CritPct": 24,
+        "CritDmg": 205,
+        "Armure": 12800,
+        "Vitesse": 2.8,
+        "Precision": 196,
+        "Esquive": 30
+      },
+      "abilities": [
+        {
+          "id": "touch_of_the_frozen_heroic",
+          "name": "Touch of the Frozen Heroic",
+          "cooldown": 20,
+          "chance": 0.3,
+          "effects": [
+            {
+              "type": "debuff",
+              "debuffType": "stat_modifier",
+              "id": "frozen_touch_debuff_heroic",
+              "name": "Frozen Touch (H)",
+              "duration": 10,
+              "statMods": [
+                {
+                  "stat": "Precision",
+                  "modifier": "multiplicative",
+                  "value": 0.65
+                },
+                {
+                  "stat": "Esquive",
+                  "modifier": "multiplicative",
+                  "value": 0.65
+                }
+              ]
+            },
+            {
+              "type": "damage",
+              "damageType": "ice",
+              "multiplier": 1.5
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "volcanic_annihilator",
+      "nom": "Volcanic Annihilator",
+      "level": 43,
+      "famille": "Giant",
+      "isBoss": true,
+      "palier": 15,
+      "stats": {
+        "PV": 15000,
+        "AttMin": 415,
+        "AttMax": 460,
+        "CritPct": 16,
+        "CritDmg": 180,
+        "Armure": 2900,
+        "Vitesse": 3.1,
+        "Precision": 127,
+        "Esquive": 17
+      },
+      "abilities": [
+        {
+          "id": "volcanic_stomp",
+          "name": "Volcanic Stomp",
+          "cooldown": 18,
+          "chance": 0.4,
+          "effects": [
+            {
+              "type": "damage",
+              "damageType": "fire",
+              "multiplier": 1.6
+            },
+            {
+              "type": "debuff",
+              "debuffType": "cc",
+              "id": "volcanic_stun",
+              "name": "Volcanic Stun",
+              "duration": 3,
+              "ccType": "stun"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "volcanic_annihilator_heroic",
+      "nom": "Volcanic Annihilator Heroic",
+      "level": 93,
+      "famille": "Giant",
+      "isBoss": true,
+      "palier": 25,
+      "stats": {
+        "PV": 152000,
+        "AttMin": 2410,
+        "AttMax": 2660,
+        "CritPct": 21,
+        "CritDmg": 205,
+        "Armure": 14900,
+        "Vitesse": 3.1,
+        "Precision": 197,
+        "Esquive": 27
+      },
+      "abilities": [
+        {
+          "id": "volcanic_stomp_heroic",
+          "name": "Volcanic Stomp Heroic",
+          "cooldown": 18,
+          "chance": 0.4,
+          "effects": [
+            {
+              "type": "damage",
+              "damageType": "fire",
+              "multiplier": 2.0
+            },
+            {
+              "type": "debuff",
+              "debuffType": "cc",
+              "id": "volcanic_stun_heroic",
+              "name": "Volcanic Stun (H)",
+              "duration": 4,
+              "ccType": "stun"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "infernal_reaver",
+      "nom": "Infernal Reaver",
+      "level": 43,
+      "famille": "Demon",
+      "isBoss": true,
+      "palier": 15,
+      "stats": {
+        "PV": 14000,
+        "AttMin": 425,
+        "AttMax": 470,
+        "CritPct": 18,
+        "CritDmg": 180,
+        "Armure": 2700,
+        "Vitesse": 2.9,
+        "Precision": 130,
+        "Esquive": 19
+      },
+      "abilities": [
+        {
+          "id": "soul_fire",
+          "name": "Soul Fire",
+          "cooldown": 15,
+          "chance": 0.5,
+          "effects": [
+            {
+              "type": "damage",
+              "damageType": "fire",
+              "multiplier": 1.5
+            },
+            {
+              "type": "debuff",
+              "debuffType": "dot",
+              "id": "soul_fire_dot",
+              "name": "Soul Fire",
+              "duration": 6,
+              "damageType": "fire",
+              "totalDamage": {
+                "source": "base_value",
+                "multiplier": 150
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "infernal_reaver_heroic",
+      "nom": "Infernal Reaver Heroic",
+      "level": 93,
+      "famille": "Demon",
+      "isBoss": true,
+      "palier": 25,
+      "stats": {
+        "PV": 142000,
+        "AttMin": 2460,
+        "AttMax": 2710,
+        "CritPct": 23,
+        "CritDmg": 205,
+        "Armure": 14700,
+        "Vitesse": 2.9,
+        "Precision": 200,
+        "Esquive": 29
+      },
+      "abilities": [
+        {
+          "id": "soul_fire_heroic",
+          "name": "Soul Fire Heroic",
+          "cooldown": 15,
+          "chance": 0.5,
+          "effects": [
+            {
+              "type": "damage",
+              "damageType": "fire",
+              "multiplier": 1.8
+            },
+            {
+              "type": "debuff",
+              "debuffType": "dot",
+              "id": "soul_fire_dot_heroic",
+              "name": "Soul Fire (H)",
+              "duration": 6,
+              "damageType": "fire",
+              "totalDamage": {
+                "source": "base_value",
+                "multiplier": 300
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "blackrock_tyrant",
+      "nom": "Blackrock Tyrant",
+      "level": 43,
+      "famille": "Humanoid",
+      "isBoss": true,
+      "palier": 15,
+      "stats": {
+        "PV": 13500,
+        "AttMin": 435,
+        "AttMax": 480,
+        "CritPct": 20,
+        "CritDmg": 180,
+        "Armure": 2600,
+        "Vitesse": 2.8,
+        "Precision": 132,
+        "Esquive": 21
+      },
+      "abilities": [
+        {
+          "id": "tyrants_decree",
+          "name": "Tyrant's Decree",
+          "cooldown": 20,
+          "chance": 0.3,
+          "effects": [
+            {
+              "type": "buff",
+              "buffType": "stat_modifier",
+              "id": "tyrants_buff",
+              "name": "Tyrant's Might",
+              "duration": 10,
+              "statMods": [
+                {
+                  "stat": "AttMin",
+                  "modifier": "multiplicative",
+                  "value": 1.30
+                },
+                {
+                  "stat": "AttMax",
+                  "modifier": "multiplicative",
+                  "value": 1.30
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "blackrock_tyrant_heroic",
+      "nom": "Blackrock Tyrant Heroic",
+      "level": 93,
+      "famille": "Humanoid",
+      "isBoss": true,
+      "palier": 25,
+      "stats": {
+        "PV": 137000,
+        "AttMin": 2510,
+        "AttMax": 2760,
+        "CritPct": 25,
+        "CritDmg": 205,
+        "Armure": 14600,
+        "Vitesse": 2.8,
+        "Precision": 202,
+        "Esquive": 31
+      },
+      "abilities": [
+        {
+          "id": "tyrants_decree_heroic",
+          "name": "Tyrant's Decree Heroic",
+          "cooldown": 20,
+          "chance": 0.3,
+          "effects": [
+            {
+              "type": "buff",
+              "buffType": "stat_modifier",
+              "id": "tyrants_buff_heroic",
+              "name": "Tyrant's Might (H)",
+              "duration": 10,
+              "statMods": [
+                {
+                  "stat": "AttMin",
+                  "modifier": "multiplicative",
+                  "value": 1.50
+                },
+                {
+                  "stat": "AttMax",
+                  "modifier": "multiplicative",
+                  "value": 1.50
+                }
+              ]
+            },
+            {
+              "type": "damage",
+              "damageType": "physical",
+              "multiplier": 1.2
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "molten_leviathan",
+      "nom": "Molten Leviathan",
+      "level": 43,
+      "famille": "Construct",
+      "isBoss": true,
+      "palier": 15,
+      "stats": {
+        "PV": 16000,
+        "AttMin": 405,
+        "AttMax": 450,
+        "CritPct": 15,
+        "CritDmg": 180,
+        "Armure": 3200,
+        "Vitesse": 3.4,
+        "Precision": 125,
+        "Esquive": 15
+      },
+      "abilities": [
+        {
+          "id": "magma_spit",
+          "name": "Magma Spit",
+          "cooldown": 12,
+          "chance": 0.6,
+          "effects": [
+            {
+              "type": "debuff",
+              "debuffType": "dot",
+              "id": "magma_spit_dot",
+              "name": "Magma Spit",
+              "duration": 12,
+              "damageType": "fire",
+              "totalDamage": {
+                "source": "base_value",
+                "multiplier": 180
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "molten_leviathan_heroic",
+      "nom": "Molten Leviathan Heroic",
+      "level": 93,
+      "famille": "Construct",
+      "isBoss": true,
+      "palier": 25,
+      "stats": {
+        "PV": 162000,
+        "AttMin": 2360,
+        "AttMax": 2610,
+        "CritPct": 20,
+        "CritDmg": 205,
+        "Armure": 15200,
+        "Vitesse": 3.4,
+        "Precision": 195,
+        "Esquive": 25
+      },
+      "abilities": [
+        {
+          "id": "magma_spit_heroic",
+          "name": "Magma Spit Heroic",
+          "cooldown": 12,
+          "chance": 0.6,
+          "effects": [
+            {
+              "type": "debuff",
+              "debuffType": "dot",
+              "id": "magma_spit_dot_heroic",
+              "name": "Magma Spit (H)",
+              "duration": 12,
+              "damageType": "fire",
+              "totalDamage": {
+                "source": "base_value",
+                "multiplier": 360
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "blazing_juggernaut",
+      "nom": "Blazing Juggernaut",
+      "level": 43,
+      "famille": "Demon",
+      "isBoss": true,
+      "palier": 15,
+      "stats": {
+        "PV": 15500,
+        "AttMin": 410,
+        "AttMax": 455,
+        "CritPct": 17,
+        "CritDmg": 180,
+        "Armure": 3000,
+        "Vitesse": 3.2,
+        "Precision": 126,
+        "Esquive": 16
+      },
+      "abilities": [
+        {
+          "id": "infernal_charge",
+          "name": "Infernal Charge",
+          "cooldown": 16,
+          "chance": 0.4,
+          "effects": [
+            {
+              "type": "damage",
+              "damageType": "physical",
+              "multiplier": 1.8
+            },
+            {
+              "type": "debuff",
+              "debuffType": "vulnerability",
+              "id": "charge_vuln",
+              "name": "Broken Armor",
+              "duration": 8,
+              "damageType": "physical",
+              "multiplier": 1.20
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "blazing_juggernaut_heroic",
+      "nom": "Blazing Juggernaut Heroic",
+      "level": 93,
+      "famille": "Demon",
+      "isBoss": true,
+      "palier": 25,
+      "stats": {
+        "PV": 157000,
+        "AttMin": 2410,
+        "AttMax": 2660,
+        "CritPct": 22,
+        "CritDmg": 205,
+        "Armure": 15000,
+        "Vitesse": 3.2,
+        "Precision": 196,
+        "Esquive": 26
+      },
+      "abilities": [
+        {
+          "id": "infernal_charge_heroic",
+          "name": "Infernal Charge Heroic",
+          "cooldown": 16,
+          "chance": 0.4,
+          "effects": [
+            {
+              "type": "damage",
+              "damageType": "physical",
+              "multiplier": 2.2
+            },
+            {
+              "type": "debuff",
+              "debuffType": "vulnerability",
+              "id": "charge_vuln_heroic",
+              "name": "Broken Armor (H)",
+              "duration": 8,
+              "damageType": "physical",
+              "multiplier": 1.30
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "verdant_colossus",
+      "nom": "Verdant Colossus",
+      "level": 46,
+      "famille": "Plant",
+      "isBoss": true,
+      "palier": 16,
+      "stats": {
+        "PV": 21000,
+        "AttMin": 505,
+        "AttMax": 550,
+        "CritPct": 11,
+        "CritDmg": 160,
+        "Armure": 4200,
+        "Vitesse": 4.4,
+        "Precision": 132,
+        "Esquive": 12
+      },
+      "abilities": [
+        {
+          "id": "overgrowth",
+          "name": "Overgrowth",
+          "cooldown": 20,
+          "chance": 0.4,
+          "effects": [
+            {
+              "type": "debuff",
+              "debuffType": "dot",
+              "id": "overgrowth_dot",
+              "name": "Overgrowth",
+              "duration": 10,
+              "damageType": "nature",
+              "totalDamage": {
+                "source": "base_value",
+                "multiplier": 250
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "verdant_colossus_heroic",
+      "nom": "Verdant Colossus Heroic",
+      "level": 96,
+      "famille": "Plant",
+      "isBoss": true,
+      "palier": 26,
+      "stats": {
+        "PV": 212000,
+        "AttMin": 2860,
+        "AttMax": 3110,
+        "CritPct": 16,
+        "CritDmg": 185,
+        "Armure": 17200,
+        "Vitesse": 4.4,
+        "Precision": 202,
+        "Esquive": 22
+      },
+      "abilities": [
+        {
+          "id": "overgrowth_heroic",
+          "name": "Overgrowth Heroic",
+          "cooldown": 20,
+          "chance": 0.4,
+          "effects": [
+            {
+              "type": "debuff",
+              "debuffType": "dot",
+              "id": "overgrowth_dot_heroic",
+              "name": "Overgrowth (H)",
+              "duration": 10,
+              "damageType": "nature",
+              "totalDamage": {
+                "source": "base_value",
+                "multiplier": 500
+              }
+            },
+            {
+              "type": "debuff",
+              "debuffType": "cc",
+              "id": "overgrowth_root_heroic",
+              "name": "Rooted (H)",
+              "duration": 4,
+              "ccType": "stun"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "emerald_dreamer",
+      "nom": "Emerald Dreamer",
+      "level": 46,
+      "famille": "Fey",
+      "isBoss": true,
+      "palier": 16,
+      "stats": {
+        "PV": 19000,
+        "AttMin": 525,
+        "AttMax": 570,
+        "CritPct": 14,
+        "CritDmg": 160,
+        "Armure": 3800,
+        "Vitesse": 4.2,
+        "Precision": 135,
+        "Esquive": 14
+      },
+      "abilities": [
+        {
+          "id": "dream_aura",
+          "name": "Dream Aura",
+          "cooldown": 25,
+          "chance": 0.3,
+          "effects": [
+            {
+              "type": "debuff",
+              "debuffType": "stat_modifier",
+              "id": "dream_aura_debuff",
+              "name": "Drowsy",
+              "duration": 15,
+              "statMods": [
+                {
+                  "stat": "Vitesse",
+                  "modifier": "multiplicative",
+                  "value": 1.20
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "emerald_dreamer_heroic",
+      "nom": "Emerald Dreamer Heroic",
+      "level": 96,
+      "famille": "Fey",
+      "isBoss": true,
+      "palier": 26,
+      "stats": {
+        "PV": 192000,
+        "AttMin": 2910,
+        "AttMax": 3160,
+        "CritPct": 19,
+        "CritDmg": 185,
+        "Armure": 16800,
+        "Vitesse": 4.2,
+        "Precision": 205,
+        "Esquive": 24
+      },
+      "abilities": [
+        {
+          "id": "dream_aura_heroic",
+          "name": "Dream Aura Heroic",
+          "cooldown": 25,
+          "chance": 0.3,
+          "effects": [
+            {
+              "type": "debuff",
+              "debuffType": "stat_modifier",
+              "id": "dream_aura_debuff_heroic",
+              "name": "Drowsy (H)",
+              "duration": 15,
+              "statMods": [
+                {
+                  "stat": "Vitesse",
+                  "modifier": "multiplicative",
+                  "value": 1.40
+                }
+              ]
+            },
+            {
+              "type": "debuff",
+              "debuffType": "cc",
+              "id": "dream_aura_sleep_heroic",
+              "name": "Sleep (H)",
+              "duration": 3,
+              "ccType": "stun"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "sylvan_goliath",
+      "nom": "Sylvan Goliath",
+      "level": 46,
+      "famille": "Giant",
+      "isBoss": true,
+      "palier": 16,
+      "stats": {
+        "PV": 22000,
+        "AttMin": 495,
+        "AttMax": 540,
+        "CritPct": 10,
+        "CritDmg": 160,
+        "Armure": 4500,
+        "Vitesse": 4.6,
+        "Precision": 130,
+        "Esquive": 11
+      },
+      "abilities": [
+        {
+          "id": "goliaths_strength",
+          "name": "Goliath's Strength",
+          "cooldown": 18,
+          "chance": 0.4,
+          "effects": [
+            {
+              "type": "buff",
+              "buffType": "stat_modifier",
+              "id": "goliath_strength_buff",
+              "name": "Goliath's Strength",
+              "duration": 12,
+              "statMods": [
+                {
+                  "stat": "AttMin",
+                  "modifier": "multiplicative",
+                  "value": 1.25
+                },
+                {
+                  "stat": "AttMax",
+                  "modifier": "multiplicative",
+                  "value": 1.25
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "sylvan_goliath_heroic",
+      "nom": "Sylvan Goliath Heroic",
+      "level": 96,
+      "famille": "Giant",
+      "isBoss": true,
+      "palier": 26,
+      "stats": {
+        "PV": 222000,
+        "AttMin": 2810,
+        "AttMax": 3060,
+        "CritPct": 15,
+        "CritDmg": 185,
+        "Armure": 17500,
+        "Vitesse": 4.6,
+        "Precision": 200,
+        "Esquive": 21
+      },
+      "abilities": [
+        {
+          "id": "goliaths_strength_heroic",
+          "name": "Goliath's Strength Heroic",
+          "cooldown": 18,
+          "chance": 0.4,
+          "effects": [
+            {
+              "type": "buff",
+              "buffType": "stat_modifier",
+              "id": "goliath_strength_buff_heroic",
+              "name": "Goliath's Strength (H)",
+              "duration": 12,
+              "statMods": [
+                {
+                  "stat": "AttMin",
+                  "modifier": "multiplicative",
+                  "value": 1.40
+                },
+                {
+                  "stat": "AttMax",
+                  "modifier": "multiplicative",
+                  "value": 1.40
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "heart_of_the_forest",
+      "nom": "Heart of the Forest",
+      "level": 46,
+      "famille": "Elemental",
+      "isBoss": true,
+      "palier": 16,
+      "stats": {
+        "PV": 20000,
+        "AttMin": 515,
+        "AttMax": 560,
+        "CritPct": 12,
+        "CritDmg": 160,
+        "Armure": 4000,
+        "Vitesse": 4.3,
+        "Precision": 134,
+        "Esquive": 13
+      },
+      "abilities": [
+        {
+          "id": "natures_blessing",
+          "name": "Nature's Blessing",
+          "cooldown": 30,
+          "chance": 0.25,
+          "effects": [
+            {
+              "type": "buff",
+              "buffType": "hot",
+              "id": "natures_blessing_hot",
+              "name": "Nature's Blessing",
+              "duration": 15,
+              "totalHeal": {
+                "source": "max_health_percentage",
+                "percentage": 0.20
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "heart_of_the_forest_heroic",
+      "nom": "Heart of the Forest Heroic",
+      "level": 96,
+      "famille": "Elemental",
+      "isBoss": true,
+      "palier": 26,
+      "stats": {
+        "PV": 202000,
+        "AttMin": 2860,
+        "AttMax": 3110,
+        "CritPct": 17,
+        "CritDmg": 185,
+        "Armure": 17000,
+        "Vitesse": 4.3,
+        "Precision": 204,
+        "Esquive": 23
+      },
+      "abilities": [
+        {
+          "id": "natures_blessing_heroic",
+          "name": "Nature's Blessing Heroic",
+          "cooldown": 30,
+          "chance": 0.25,
+          "effects": [
+            {
+              "type": "buff",
+              "buffType": "hot",
+              "id": "natures_blessing_hot_heroic",
+              "name": "Nature's Blessing (H)",
+              "duration": 15,
+              "totalHeal": {
+                "source": "max_health_percentage",
+                "percentage": 0.30
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "void_harbinger",
+      "nom": "Void Harbinger",
+      "level": 49,
+      "famille": "Aberration",
+      "isBoss": true,
+      "palier": 17,
+      "stats": {
+        "PV": 33000,
+        "AttMin": 730,
+        "AttMax": 820,
+        "CritPct": 21,
+        "CritDmg": 200,
+        "Armure": 4700,
+        "Vitesse": 2.7,
+        "Precision": 162,
+        "Esquive": 27
+      },
+      "abilities": [
+        {
+          "id": "void_lash",
+          "name": "Void Lash",
+          "cooldown": 15,
+          "chance": 0.5,
+          "effects": [
+            {
+              "type": "damage",
+              "damageType": "shadow",
+              "multiplier": 1.5
+            },
+            {
+              "type": "debuff",
+              "debuffType": "stat_modifier",
+              "id": "void_lash_debuff",
+              "name": "Void-Touched",
+              "duration": 8,
+              "statMods": [
+                {
+                  "stat": "CritDmg",
+                  "modifier": "multiplicative",
+                  "value": 0.85
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "void_harbinger_heroic",
+      "nom": "Void Harbinger Heroic",
+      "level": 99,
+      "famille": "Aberration",
+      "isBoss": true,
+      "palier": 27,
+      "stats": {
+        "PV": 332000,
+        "AttMin": 3610,
+        "AttMax": 4060,
+        "CritPct": 26,
+        "CritDmg": 225,
+        "Armure": 20700,
+        "Vitesse": 2.7,
+        "Precision": 232,
+        "Esquive": 37
+      },
+      "abilities": [
+        {
+          "id": "void_lash_heroic",
+          "name": "Void Lash Heroic",
+          "cooldown": 15,
+          "chance": 0.5,
+          "effects": [
+            {
+              "type": "damage",
+              "damageType": "shadow",
+              "multiplier": 1.8
+            },
+            {
+              "type": "debuff",
+              "debuffType": "stat_modifier",
+              "id": "void_lash_debuff_heroic",
+              "name": "Void-Touched (H)",
+              "duration": 8,
+              "statMods": [
+                {
+                  "stat": "CritDmg",
+                  "modifier": "multiplicative",
+                  "value": 0.70
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "sunken_horror",
+      "nom": "Sunken Horror",
+      "level": 49,
+      "famille": "Aberration",
+      "isBoss": true,
+      "palier": 17,
+      "stats": {
+        "PV": 34000,
+        "AttMin": 710,
+        "AttMax": 800,
+        "CritPct": 19,
+        "CritDmg": 200,
+        "Armure": 4900,
+        "Vitesse": 2.9,
+        "Precision": 160,
+        "Esquive": 26
+      },
+      "abilities": [
+        {
+          "id": "tentacle_slam",
+          "name": "Tentacle Slam",
+          "cooldown": 12,
+          "chance": 0.6,
+          "effects": [
+            {
+              "type": "damage",
+              "damageType": "physical",
+              "multiplier": 1.7
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "sunken_horror_heroic",
+      "nom": "Sunken Horror Heroic",
+      "level": 99,
+      "famille": "Aberration",
+      "isBoss": true,
+      "palier": 27,
+      "stats": {
+        "PV": 342000,
+        "AttMin": 3560,
+        "AttMax": 4010,
+        "CritPct": 24,
+        "CritDmg": 225,
+        "Armure": 20900,
+        "Vitesse": 2.9,
+        "Precision": 230,
+        "Esquive": 36
+      },
+      "abilities": [
+        {
+          "id": "tentacle_slam_heroic",
+          "name": "Tentacle Slam Heroic",
+          "cooldown": 12,
+          "chance": 0.6,
+          "effects": [
+            {
+              "type": "damage",
+              "damageType": "physical",
+              "multiplier": 2.1
+            },
+            {
+              "type": "debuff",
+              "debuffType": "cc",
+              "id": "tentacle_stun_heroic",
+              "name": "Grabbed (H)",
+              "duration": 2,
+              "ccType": "stun"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "nyalotha_prophet",
+      "nom": "Ny'alotha Prophet",
+      "level": 49,
+      "famille": "Humanoid",
+      "isBoss": true,
+      "palier": 17,
+      "stats": {
+        "PV": 31000,
+        "AttMin": 750,
+        "AttMax": 840,
+        "CritPct": 22,
+        "CritDmg": 200,
+        "Armure": 4400,
+        "Vitesse": 2.6,
+        "Precision": 165,
+        "Esquive": 29
+      },
+      "abilities": [
+        {
+          "id": "prophecy_of_madness",
+          "name": "Prophecy of Madness",
+          "cooldown": 25,
+          "chance": 0.3,
+          "effects": [
+            {
+              "type": "debuff",
+              "debuffType": "stat_modifier",
+              "id": "madness_debuff",
+              "name": "Madness",
+              "duration": 12,
+              "statMods": [
+                {
+                  "stat": "Precision",
+                  "modifier": "multiplicative",
+                  "value": 0.70
+                },
+                {
+                  "stat": "CritPct",
+                  "modifier": "multiplicative",
+                  "value": 0.70
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "nyalotha_prophet_heroic",
+      "nom": "Ny'alotha Prophet Heroic",
+      "level": 99,
+      "famille": "Humanoid",
+      "isBoss": true,
+      "palier": 27,
+      "stats": {
+        "PV": 312000,
+        "AttMin": 3660,
+        "AttMax": 4110,
+        "CritPct": 27,
+        "CritDmg": 225,
+        "Armure": 20400,
+        "Vitesse": 2.6,
+        "Precision": 235,
+        "Esquive": 39
+      },
+      "abilities": [
+        {
+          "id": "prophecy_of_madness_heroic",
+          "name": "Prophecy of Madness Heroic",
+          "cooldown": 25,
+          "chance": 0.3,
+          "effects": [
+            {
+              "type": "debuff",
+              "debuffType": "stat_modifier",
+              "id": "madness_debuff_heroic",
+              "name": "Madness (H)",
+              "duration": 12,
+              "statMods": [
+                {
+                  "stat": "Precision",
+                  "modifier": "multiplicative",
+                  "value": 0.50
+                },
+                {
+                  "stat": "CritPct",
+                  "modifier": "multiplicative",
+                  "value": 0.50
+                }
+              ]
+            },
+            {
+              "type": "debuff",
+              "debuffType": "dot",
+              "id": "madness_dot_heroic",
+              "name": "Whispers of Ny'alotha (H)",
+              "duration": 12,
+              "damageType": "shadow",
+              "totalDamage": {
+                "source": "base_value",
+                "multiplier": 400
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "shadow_of_rlyeh",
+      "nom": "Shadow of R'lyeh",
+      "level": 49,
+      "famille": "Aberration",
+      "isBoss": true,
+      "palier": 17,
+      "stats": {
+        "PV": 35000,
+        "AttMin": 700,
+        "AttMax": 790,
+        "CritPct": 20,
+        "CritDmg": 200,
+        "Armure": 5000,
+        "Vitesse": 3.0,
+        "Precision": 158,
+        "Esquive": 25
+      },
+      "abilities": [
+        {
+          "id": "shadowy_embrace",
+          "name": "Shadowy Embrace",
+          "cooldown": 18,
+          "chance": 0.4,
+          "effects": [
+            {
+              "type": "debuff",
+              "debuffType": "vulnerability",
+              "id": "shadow_vuln",
+              "name": "Shadow Vulnerability",
+              "duration": 10,
+              "damageType": "shadow",
+              "multiplier": 1.25
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "shadow_of_rlyeh_heroic",
+      "nom": "Shadow of R'lyeh Heroic",
+      "level": 99,
+      "famille": "Aberration",
+      "isBoss": true,
+      "palier": 27,
+      "stats": {
+        "PV": 352000,
+        "AttMin": 3510,
+        "AttMax": 3960,
+        "CritPct": 25,
+        "CritDmg": 225,
+        "Armure": 21000,
+        "Vitesse": 3.0,
+        "Precision": 228,
+        "Esquive": 35
+      },
+      "abilities": [
+        {
+          "id": "shadowy_embrace_heroic",
+          "name": "Shadowy Embrace Heroic",
+          "cooldown": 18,
+          "chance": 0.4,
+          "effects": [
+            {
+              "type": "debuff",
+              "debuffType": "vulnerability",
+              "id": "shadow_vuln_heroic",
+              "name": "Shadow Vulnerability (H)",
+              "duration": 10,
+              "damageType": "shadow",
+              "multiplier": 1.50
+            },
+            {
+              "type": "damage",
+              "damageType": "shadow",
+              "multiplier": 1.4
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
This commit addresses the issue of duplicated bosses in dungeons.

- Identified all duplicated bosses in dungeons.json.
- Created new unique bosses in monsters.json for each dungeon that had a duplicated boss.
- Updated dungeons.json to use the new unique boss IDs.
- Verified that there are no more duplicated bosses.