### PR TITLE
feat: Add hero reset and rename features

### DIFF
--- a/src/features/combat/components/CombatLog.tsx
+++ b/src/features/combat/components/CombatLog.tsx
@@ -48,7 +48,10 @@ const getLogEntryColor = (type: CombatLogEntry['type']) => {
 
 const LogMessage = ({ entry }: { entry: CombatLogEntry }) => {
     const color = getLogEntryColor(entry.type);
-    const equipment = useGameStore(s => s.inventory.equipment);
+    const equipment = useGameStore(state => {
+        const activeHero = state.getActiveHero();
+        return activeHero ? activeHero.inventory.equipment : {};
+    });
 
     if (entry.type === 'loot' && entry.item) {
         return (

--- a/src/features/hero-selection/HeroSelectionView.tsx
+++ b/src/features/hero-selection/HeroSelectionView.tsx
@@ -15,20 +15,21 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
-import { User, Trash2, Play, PlusCircle } from 'lucide-react';
+import { User, Trash2, Play, PlusCircle, RefreshCw } from 'lucide-react';
 
 export function HeroSelectionView() {
-  const { heroes, selectHero, deleteHero, gameData, startCharacterCreation } = useGameStore(state => ({
+  const { heroes, selectHero, deleteHero, resetHero, gameData, startCharacterCreation } = useGameStore(state => ({
     heroes: state.heroes,
     selectHero: state.selectHero,
     deleteHero: state.deleteHero,
+    resetHero: state.resetHero,
     gameData: state.gameData,
     startCharacterCreation: state.startCharacterCreation,
   }));
 
   const getClassName = (classId: string | null) => {
     if (!classId) return 'Inconnu';
-    return gameData.classes.find(c => c.id === classId)?.name || 'Inconnu';
+    return gameData.classes.find(c => c.id === classId)?.nom || 'Inconnu';
   };
 
   return (
@@ -59,6 +60,28 @@ export function HeroSelectionView() {
                 </Button>
                 <AlertDialog>
                   <AlertDialogTrigger asChild>
+                    <Button variant="outline" size="sm" className="text-yellow-400 border-yellow-400 hover:bg-yellow-400 hover:text-gray-900">
+                      <RefreshCw className="h-4 w-4" />
+                    </Button>
+                  </AlertDialogTrigger>
+                  <AlertDialogContent>
+                    <AlertDialogHeader>
+                      <AlertDialogTitle>Réinitialiser ce héros ?</AlertDialogTitle>
+                      <AlertDialogDescription>
+                        Cette action réinitialisera toute la progression, l&apos;équipement et l&apos;or de{' '}
+                        <span className="font-bold mx-1">{hero.player.name}</span> au niveau 1. Cette action est irréversible. Voulez-vous continuer ?
+                      </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                      <AlertDialogCancel>Annuler</AlertDialogCancel>
+                      <AlertDialogAction onClick={() => resetHero(hero.id)} className="bg-yellow-400 text-gray-900 hover:bg-yellow-500">
+                        Oui, réinitialiser
+                      </AlertDialogAction>
+                    </AlertDialogFooter>
+                  </AlertDialogContent>
+                </AlertDialog>
+                <AlertDialog>
+                  <AlertDialogTrigger asChild>
                     <Button variant="destructive" size="sm">
                       <Trash2 className="h-4 w-4" />
                     </Button>
@@ -67,7 +90,7 @@ export function HeroSelectionView() {
                     <AlertDialogHeader>
                       <AlertDialogTitle>Êtes-vous sûr de vouloir supprimer ce héros ?</AlertDialogTitle>
                       <AlertDialogDescription>
-                        Cette action est irréversible. Toute la progression, l'équipement et l'or de
+                        Cette action est irréversible. Toute la progression, l&apos;équipement et l&apos;or de
                         <span className="font-bold mx-1">{hero.player.name}</span>
                         seront définitivement perdus.
                       </AlertDialogDescription>

--- a/src/features/town/ScribeView.tsx
+++ b/src/features/town/ScribeView.tsx
@@ -1,0 +1,116 @@
+'use client';
+
+import * as React from 'react';
+import { useState } from 'react';
+import { useGameStore } from '@/state/gameStore';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
+import { useToast } from '@/hooks/use-toast';
+import { RENAME_COST } from '@/lib/constants';
+import { ArrowLeft } from 'lucide-react';
+import { isValidName } from '@/lib/utils';
+
+interface ScribeViewProps {
+  onBack: () => void;
+}
+
+export function ScribeView({ onBack }: ScribeViewProps) {
+  const { renameActiveHero, getActiveHero } = useGameStore((state) => ({
+    renameActiveHero: state.renameActiveHero,
+    getActiveHero: state.getActiveHero,
+  }));
+  const { toast } = useToast();
+
+  const activeHero = getActiveHero();
+  const [newName, setNewName] = useState(activeHero?.player.name || '');
+
+  if (!activeHero) {
+    return (
+      <div className="text-center p-4">
+        <p>Aucun héros actif.</p>
+        <Button onClick={onBack} className="mt-4">Retour</Button>
+      </div>
+    );
+  }
+
+  const handleRename = () => {
+    if (!isValidName(newName)) {
+      toast({
+        title: 'Nom invalide',
+        description: 'Le nom doit contenir entre 3 et 16 caractères et ne peut pas contenir de caractères spéciaux.',
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    if (activeHero.inventory.gold < RENAME_COST) {
+      toast({
+        title: 'Or insuffisant',
+        description: `Vous avez besoin de ${RENAME_COST} or pour changer de nom.`,
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    const success = renameActiveHero(newName);
+
+    if (success) {
+      toast({
+        title: 'Succès !',
+        description: `Votre nom a été changé en ${newName}.`,
+      });
+    } else {
+      // This case might be redundant due to the checks above, but it's a good fallback.
+      toast({
+        title: 'Erreur',
+        description: 'Le changement de nom a échoué pour une raison inconnue.',
+        variant: 'destructive',
+      });
+    }
+  };
+
+  const hasEnoughGold = activeHero.inventory.gold >= RENAME_COST;
+  const isNameUnchanged = newName === activeHero.player.name;
+  const isNameInvalid = !isValidName(newName);
+
+  return (
+    <Card className="w-full max-w-md mx-auto bg-gray-800 border-gray-700 text-white">
+      <CardHeader>
+        <div className="flex items-center justify-between">
+          <Button variant="ghost" size="icon" onClick={onBack}>
+            <ArrowLeft className="h-6 w-6" />
+          </Button>
+          <CardTitle className="text-2xl font-bold text-center flex-grow">Le Scribe</CardTitle>
+          <div className="w-8"></div> {/* Spacer to keep title centered */}
+        </div>
+        <CardDescription className="text-center text-gray-400 pt-2">Changement de nom</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <p className="text-center text-gray-300">
+          Pour la modique somme de <span className="font-bold text-yellow-400">{RENAME_COST}</span> or, je peux inscrire votre nouveau nom dans les annales.
+        </p>
+        <div className="space-y-2">
+          <label htmlFor="newName" className="text-sm font-medium text-gray-300">Nouveau nom</label>
+          <Input
+            id="newName"
+            type="text"
+            value={newName}
+            onChange={(e) => setNewName(e.target.value)}
+            placeholder="Entrez votre nouveau nom"
+            className="bg-gray-700 border-gray-600 text-white"
+          />
+        </div>
+      </CardContent>
+      <CardFooter>
+        <Button
+          onClick={handleRename}
+          className="w-full"
+          disabled={!hasEnoughGold || isNameUnchanged || isNameInvalid}
+        >
+          Confirmer le changement
+        </Button>
+      </CardFooter>
+    </Card>
+  );
+}

--- a/src/features/town/TownView.tsx
+++ b/src/features/town/TownView.tsx
@@ -26,8 +26,10 @@ import { PlayerBanner } from '../player/PlayerBanner';
 import React, { useState, useEffect } from 'react';
 import { cn } from '@/lib/utils';
 import { CraftingView } from './CraftingView';
+import { ScribeView } from './ScribeView';
 
 type TownTab = 'town' | 'dungeons' | 'character' | 'vendors';
+type TownSubView = 'main' | 'scribe';
 
 export function TownView() {
   const { resetGame, townView, setTownView, setActiveSubView } = useGameStore(state => ({
@@ -37,8 +39,12 @@ export function TownView() {
     setActiveSubView: state.setActiveSubView,
   }));
   const [activeTab, setActiveTab] = useState<TownTab>('town');
+  const [townSubView, setTownSubView] = useState<TownSubView>('main');
 
   useEffect(() => {
+    // Reset sub-view when changing main tabs
+    setTownSubView('main');
+
     switch(activeTab) {
       case 'town':
         setActiveSubView('TOWN');
@@ -58,17 +64,27 @@ export function TownView() {
   const renderContent = () => {
     switch (activeTab) {
       case 'town':
+        if (townSubView === 'scribe') {
+          return <div className="p-4"><ScribeView onBack={() => setTownSubView('main')} /></div>;
+        }
         return (
           <ScrollArea className="h-full">
-            {/* Utilisation d'une grille pour une mise en page plus riche */}
             <div className="grid grid-cols-1 md:grid-cols-2 gap-6 p-4">
-              {/* Le journal de quêtes prend toute la largeur sur les grands écrans */}
               <div className="md:col-span-2">
                 <QuestsView />
               </div>
-              {/* L'auberge, une action clé */}
               <InnView />
-              {/* La réputation, pour suivre la progression à long terme */}
+              <div className="p-6 bg-gray-800/50 rounded-lg flex flex-col justify-between">
+                <div>
+                  <h3 className="text-xl font-bold text-white mb-2">Le Scribe</h3>
+                  <p className="text-gray-400 mb-4">
+                    Changez de nom pour la postérité. Un service rapide, mais pas gratuit.
+                  </p>
+                </div>
+                <Button onClick={() => setTownSubView('scribe')} className="mt-auto">
+                  Parler au Scribe
+                </Button>
+              </div>
               <div className="md:col-span-2">
                 <ReputationView />
               </div>


### PR DESCRIPTION
This commit introduces several new hero management features:

- **Hero Reset:** Players can now reset a hero's progress from the selection screen. This action resets their level, XP, gold, and inventory, but preserves their name and class. A confirmation dialog is included to prevent accidental resets.

- **Hero Rename:** A "Scribe" NPC is now available in the town. Players can interact with the Scribe to open a new UI where they can rename their active hero for a fee (RENAME_COST). The UI provides feedback on success or failure.

- **Refactoring:** The logic for initializing a new character's class-specific attributes (stats, skills) has been refactored into a shared helper function, `initializePlayerForClass`. This is now used by both the character creation and reset functions, reducing code duplication.

- **Bug Fixes:**
  - Fixed a bug in `CombatLog` where it was trying to access inventory from the root of the game state instead of from the active hero.
  - Fixed a property access error in `HeroSelectionView` (`.nom` instead of `.name`).
  - Fixed several unescaped entity errors found by the linter.

The first requested task, adding a button to switch heroes, was found to be already implemented.