### PR TITLE
fix(crafting, ui): Correct salvage logic and reposition music player

### DIFF
--- a/src/features/town/components/MusicControls.tsx
+++ b/src/features/town/components/MusicControls.tsx
@@ -43,7 +43,7 @@ const MusicControls = () => {
   }
 
   return (
-    <div className="fixed bottom-4 right-4 bg-gray-900 bg-opacity-75 text-white p-3 rounded-lg shadow-lg flex items-center space-x-4 z-50">
+    <div className="fixed bottom-4 left-4 bg-gray-900 bg-opacity-75 text-white p-3 rounded-lg shadow-lg flex items-center space-x-4 z-50">
       <FaPlay className="text-green-400" />
       <div className="flex-grow min-w-0">
         <p className="text-sm font-bold truncate" title={trackName}>


### PR DESCRIPTION
This commit addresses two independent issues reported by the user.

First, the logic for dismantling items has been corrected. Previously, all items, including crafted ones, would yield random materials based on their item level and rarity. This logic has been updated to first check if an item has a corresponding crafting recipe by matching its `baseId`. If a recipe is found, the function now returns approximately 50% of the original materials required for the craft.

Additionally, based on user feedback, the fallback logic for non-crafted items was also corrected. It no longer uses invalid component IDs like `raw-hide` and `iron-ore`. Instead, it now provides valid, low-tier components such as `light_leather` and `copper_ingot`, resolving the issue of "weird materials" appearing.

Second, the music player UI component, which was causing layout issues by overlapping with other menus, has been repositioned. Its CSS was changed to place it in the bottom-left corner of the screen instead of the bottom-right, providing a less intrusive user experience.